### PR TITLE
benchmark.ps1: ship the loop + auto-playlist fixes

### DIFF
--- a/BuildMpvUpscale2xAnimeJaNai/mpv-upscale-2x_animejanai/animejanai/benchmarks/benchmark.ps1
+++ b/BuildMpvUpscale2xAnimeJaNai/mpv-upscale-2x_animejanai/animejanai/benchmarks/benchmark.ps1
@@ -63,16 +63,19 @@ $resolutions = Get-ChildItem $PSScriptRoot -Filter "*.mp4" | ForEach-Object {
     $_.BaseName
 } | Sort-Object { [int]($_ -split 'x')[0] }
 
+# Frame counts. No --loop-file: it defeats --frames (mpv never quits a looping
+# file), so the high count must fit within one pass of the bundled clips (each
+# is ~90 s, ~2157 frames at 23.976 fps), with margin.
 $warmupFrames = 200
 $lowFrames    = 500
-$highFrames   = 3500
+$highFrames   = 1800
 
 function Invoke-MpvFrames($video, $vf, $n) {
     # & with splatting quotes each arg correctly; -- guards the path so a clip
     # name with spaces/dashes can't be parsed as more options or a stdin '-'.
     $a = @(
         '--process-instance=multi', '--auto-load-folder=no', '--untimed', '--no-audio',
-        '--vo=null', '--keep-open=no', '--idle=no', '--sid=no', '--loop-file=inf',
+        '--vo=null', '--keep-open=no', '--idle=no', '--sid=no',
         '--no-resume-playback', '--save-position-on-quit=no', '--start=0',
         "--vf=$vf", "--frames=$n", '--', $video
     )

--- a/BuildMpvUpscale2xAnimeJaNai/mpv-upscale-2x_animejanai/animejanai/benchmarks/benchmark.ps1
+++ b/BuildMpvUpscale2xAnimeJaNai/mpv-upscale-2x_animejanai/animejanai/benchmarks/benchmark.ps1
@@ -85,8 +85,20 @@ function Invoke-MpvFrames($video, $vf, $n) {
 $table = @{}
 foreach ($name in $slots.Keys) { $table[$name] = [ordered]@{} }
 
+# mpv.net auto-loads every file in the opened file's folder into a playlist, and
+# --auto-load-folder=no on the command line does not reliably suppress it. If we
+# played benchmarks/<res>.mp4 directly, each run would also play every other
+# resolution and the timing would be meaningless. So copy each clip into its own
+# clean temp folder and play it from there - a one-file folder has nothing to
+# auto-load.
+$clipRoot = Join-Path ([System.IO.Path]::GetTempPath()) "animejanai-bench"
+Remove-Item $clipRoot -Recurse -Force -ErrorAction SilentlyContinue
+
 foreach ($res in $resolutions) {
-    $video = Join-Path $PSScriptRoot "$res.mp4"
+    $cellDir = Join-Path $clipRoot $res
+    New-Item -ItemType Directory -Path $cellDir -Force | Out-Null
+    $video = Join-Path $cellDir "$res.mp4"
+    Copy-Item (Join-Path $PSScriptRoot "$res.mp4") $video -Force
     foreach ($name in $slots.Keys) {
         $vf = $vfBase -replace 'slot=\d+', ("slot=" + $slots[$name])
         Write-Host -NoNewline ("{0,-12} {1,-10} " -f $name, $res)
@@ -105,6 +117,8 @@ foreach ($res in $resolutions) {
         }
     }
 }
+
+Remove-Item $clipRoot -Recurse -Force -ErrorAction SilentlyContinue
 
 # Markdown table - same shape the Submit-to-Catalog parser expects.
 $lines = @()


### PR DESCRIPTION
These two fixes landed on native-filter-migration after PR #69 was already merged, so main still has the broken benchmark. Includes: drop --loop-file=inf (it defeats --frames -> infinite hang) capped at 1800 frames, and isolate each clip in its own temp folder (mpv.net ignores --auto-load-folder=no, so runs were auto-playlisting every resolution).