### PR TITLE
site: fix archived-benchmarks wiki link

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -53,7 +53,7 @@
   <p class="meta">
     Submit your own from the AnimeJaNai Manager (Run Benchmarks, then Submit to Catalog).
     Pre-3.4.0 results (VapourSynth baseline) are in the
-    <a href="https://github.com/the-database/mpv-upscale-2x_animejanai/wiki/Benchmarks">archived wiki page</a>.
+    <a href="https://github.com/the-database/mpv-upscale-2x_animejanai/wiki/Benchmarks-(Archive)">archived wiki page</a>.
     Project: <a href="https://github.com/the-database/mpv-upscale-2x_animejanai">mpv-upscale-2x_animejanai</a>.
   </p>
 


### PR DESCRIPTION
One-line follow-up that missed PR #72's merge: point the footer 'archived wiki page' link at /wiki/Benchmarks-(Archive) instead of /wiki/Benchmarks.