### PR TITLE
Native default-slot startup + Manager pin 0.2.4 (incl. DML benchmark fix)

### DIFF
--- a/BuildMpvUpscale2xAnimeJaNai/Program.cs
+++ b/BuildMpvUpscale2xAnimeJaNai/Program.cs
@@ -24,7 +24,7 @@ const string VsMlrtCudaVersion    = "v16.test1";
 const string AjiVersion           = "v0.2.0";       // github.com/the-database/animejanai-inference release tag (ABI v7, pipelined)
 const string SevenZipVersion      = "2501";         // 7-zip "extra" standalone console version
 const string MpvNetVersion        = "v7.1.2.0";
-const string ManagerVersion       = "0.2.3";        // github.com/the-database/AnimeJaNaiConfEditor release tag (AnimeJaNai Manager)
+const string ManagerVersion       = "0.2.4";        // github.com/the-database/AnimeJaNaiConfEditor release tag (AnimeJaNai Manager)
 
 // DirectML backend runtime (backend=DirectML in animejanai.conf). These are
 // the last DirectML-flavored releases: Microsoft moved DML to sustained

--- a/BuildMpvUpscale2xAnimeJaNai/Program.cs
+++ b/BuildMpvUpscale2xAnimeJaNai/Program.cs
@@ -24,7 +24,7 @@ const string VsMlrtCudaVersion    = "v16.test1";
 const string AjiVersion           = "v0.2.0";       // github.com/the-database/animejanai-inference release tag (ABI v7, pipelined)
 const string SevenZipVersion      = "2501";         // 7-zip "extra" standalone console version
 const string MpvNetVersion        = "v7.1.2.0";
-const string ManagerVersion       = "0.2.2";        // github.com/the-database/AnimeJaNaiConfEditor release tag (AnimeJaNai Manager)
+const string ManagerVersion       = "0.2.3";        // github.com/the-database/AnimeJaNaiConfEditor release tag (AnimeJaNai Manager)
 
 // DirectML backend runtime (backend=DirectML in animejanai.conf). These are
 // the last DirectML-flavored releases: Microsoft moved DML to sustained

--- a/BuildMpvUpscale2xAnimeJaNai/mpv-upscale-2x_animejanai/animejanai/animejanai.conf
+++ b/BuildMpvUpscale2xAnimeJaNai/mpv-upscale-2x_animejanai/animejanai/animejanai.conf
@@ -1,5 +1,5 @@
 [global]
-config_version=2
+config_version=3
 backend=TensorRT
 logging=yes
 [slot_1]

--- a/BuildMpvUpscale2xAnimeJaNai/mpv-upscale-2x_animejanai/animejanai/benchmarks/benchmark.ps1
+++ b/BuildMpvUpscale2xAnimeJaNai/mpv-upscale-2x_animejanai/animejanai/benchmarks/benchmark.ps1
@@ -28,9 +28,13 @@ if (-not (Test-Path $mpvnet)) {
     exit 1
 }
 
-# Backend from [global] in animejanai.conf - for the report header only. The
-# native filter dispatches to aji_trt/aji_dml itself and animejanai_backend.lua
-# sets the right hwdec, so we must NOT override decoding here.
+# Backend from [global] in animejanai.conf. The native filter dispatches to
+# aji_trt/aji_dml itself, but the decoder must match: TensorRT consumes CUDA
+# frames (nvdec), DirectML/NCNN consume D3D11 frames (d3d11va). In normal
+# playback animejanai_backend.lua sets this, but it does not run reliably under
+# this mpvnet.com benchmark launch, so set hwdec here explicitly. Without it,
+# the conf default hwdec=nvdec is used and a non-NVIDIA machine fails with
+# "Cannot load nvcuda.dll".
 $backend = "TensorRT"
 if (Test-Path $conf) {
     $inGlobal = $false
@@ -39,6 +43,7 @@ if (Test-Path $conf) {
         elseif ($inGlobal -and $line -match '^backend=(\S+)') { $backend = $Matches[1] }
     }
 }
+$hwdec = if ($backend -match '^(?i:directml|ncnn)$') { 'd3d11va' } else { 'nvdec' }
 
 # Pull the aji filter string from the managed conf so paths stay in sync; only
 # the slot is swapped per template below.
@@ -76,7 +81,7 @@ function Invoke-MpvFrames($video, $vf, $n) {
     # name with spaces/dashes can't be parsed as more options or a stdin '-'.
     $a = @(
         '--process-instance=multi', '--auto-load-folder=no', '--untimed', '--no-audio',
-        '--vo=null', '--keep-open=no', '--idle=no', '--sid=no',
+        '--vo=null', '--keep-open=no', '--idle=no', '--sid=no', "--hwdec=$hwdec",
         '--no-resume-playback', '--save-position-on-quit=no', '--start=0',
         "--vf=$vf", "--frames=$n", '--', $video
     )

--- a/BuildMpvUpscale2xAnimeJaNai/mpv-upscale-2x_animejanai/animejanai/benchmarks/benchmark.ps1
+++ b/BuildMpvUpscale2xAnimeJaNai/mpv-upscale-2x_animejanai/animejanai/benchmarks/benchmark.ps1
@@ -80,7 +80,13 @@ function Invoke-MpvFrames($video, $vf, $n) {
         '--no-resume-playback', '--save-position-on-quit=no', '--start=0',
         "--vf=$vf", "--frames=$n", '--', $video
     )
-    return (Measure-Command { & $mpvnet @a *> $null }).TotalSeconds
+    # The DirectML/onnxruntime backend prints warnings to stderr; with
+    # ErrorActionPreference=Stop, PowerShell turns native stderr into a fatal
+    # error, so relax it around the call (all output is discarded anyway).
+    $eap = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try { return (Measure-Command { & $mpvnet @a *> $null }).TotalSeconds }
+    finally { $ErrorActionPreference = $eap }
 }
 
 $table = @{}

--- a/BuildMpvUpscale2xAnimeJaNai/mpv-upscale-2x_animejanai/portable_config/scripts/animejanai_backend.lua
+++ b/BuildMpvUpscale2xAnimeJaNai/mpv-upscale-2x_animejanai/portable_config/scripts/animejanai_backend.lua
@@ -28,6 +28,7 @@ local function read_conf()
         return nil, false
     end
     local backend
+    local default_slot
     local rife = false
     local in_global = false
     for line in f:lines() do
@@ -39,13 +40,17 @@ local function read_conf()
             if v then
                 backend = v
             end
+            local d = line:match('^default_slot=(-?%d+)')
+            if d then
+                default_slot = tonumber(d)
+            end
         end
         if line:match('^chain_%d+_rife=yes') or line:match('^chain_%d+_rife=true') then
             rife = true
         end
     end
     f:close()
-    return backend, rife
+    return backend, rife, default_slot
 end
 
 local function exists(rel)
@@ -125,7 +130,7 @@ local function check_components(backend, rife_configured)
     end)
 end
 
-local backend_raw, rife_configured = read_conf()
+local backend_raw, rife_configured, default_slot = read_conf()
 local backend = (backend_raw or 'TensorRT'):lower()
 local hwdec = 'nvdec'
 if backend == 'directml' or backend == 'ncnn' then
@@ -135,4 +140,21 @@ end
 mp.set_property('hwdec', hwdec)
 msg.info(string.format('backend %s -> hwdec=%s%s', backend, hwdec,
                        hwdec == 'd3d11va' and ', gpu-api=d3d11' or ''))
+
+-- The Manager's "Set as Default Profile" stores the chosen slot here. The vf
+-- line bakes in Balanced (1002); if the user picked another default, apply it
+-- once after the first file loads (the filter only exists then). Only the first
+-- file is touched so a manual slot switch later in the session sticks.
+if default_slot then
+    local applied = false
+    mp.register_event('file-loaded', function()
+        if applied then
+            return
+        end
+        applied = true
+        msg.info('applying default slot ' .. default_slot)
+        mp.commandv('script-message', 'aji-slot', tostring(default_slot))
+    end)
+end
+
 check_components(backend, rife_configured)


### PR DESCRIPTION
Release-prep bundle for v3.4.0.

## Default profile applied at startup (native filter)
The Manager's **Set as Default Profile** now stores the chosen slot as `[global] default_slot` in `animejanai.conf` (see the matching AnimeJaNaiConfEditor PR #2). `scripts/animejanai_backend.lua` reads it and applies it once on the first `file-loaded` via `script-message aji-slot N`:

- Quality / Balanced / Performance -> 1001 / 1002 / 1003
- custom profiles -> 1-9, Off -> 0
- absent -> the vf line's baked-in Balanced applies

Only the first file is touched, so a manual slot switch later in the session sticks. Unknown `[global]` keys are already ignored by the native conf loader, so the filter is unaffected.

## Config + pin
- Bundled default `animejanai.conf` -> `config_version=3` (matches the Manager's TRT precision v2->v3 migration).
- Manager pin -> **0.2.4** (default-slot persistence + precision-selector removal + restart/apply notes).

## Also included
- benchmark.ps1: don't let native DirectML/onnxruntime stderr fail the run.

Merge order: cut the **0.2.4** Manager release first (the build downloads it by tag), then merge this.