### PR TITLE
benchmark: time-bound + skip below-real-time, with a too-slow catalog marker

### DIFF
--- a/BuildMpvUpscale2xAnimeJaNai/mpv-upscale-2x_animejanai/animejanai/benchmarks/benchmark.ps1
+++ b/BuildMpvUpscale2xAnimeJaNai/mpv-upscale-2x_animejanai/animejanai/benchmarks/benchmark.ps1
@@ -11,10 +11,15 @@
 # button). mpv windows open and close on their own during the run - do not
 # close or click them, or the timings are invalid.
 #
-# Method: each cell runs mpvnet.com uncapped (--untimed --vo=null), looping a
-# short clip. A warmup run builds the TensorRT engine and fills the pipeline,
-# then two timed runs (low/high frame counts) are subtracted so the fixed
-# startup cost cancels out:  fps = (high - low) / (t_high - t_low).
+# Method: each cell runs mpvnet.com uncapped (--untimed --vo=null) over a short
+# clip. A warmup run builds the TensorRT engine and fills the pipeline, then a
+# probe run measures a rough rate, which sizes a second (window) run so the two
+# timed points are subtracted to cancel fixed startup cost:
+#   fps = (window_frames - probe_frames) / (t_window - t_probe)
+# Sizing the window from the probe keeps each cell to about the same wall time
+# regardless of GPU speed. Each run is killed if it can't sustain $fpsFloor fps,
+# so hopelessly slow cells (well below real-time) are skipped instead of running
+# for many minutes; a skipped cell is left blank.
 
 $ErrorActionPreference = "Stop"
 $root        = Split-Path -Parent $PSScriptRoot       # animejanai/
@@ -61,7 +66,8 @@ Write-Host "mpv windows will open and close on their own. Do NOT close or click"
 Write-Host "them while the benchmark runs, or the results will be invalid."
 Write-Host "(TensorRT builds an engine per resolution on the first run, about a"
 Write-Host " minute each and cached afterward; the full sweep takes several minutes,"
-Write-Host " longer on slower GPUs.)"
+Write-Host " longer on slower GPUs. Cells too slow to be usable, under $fpsFloor fps, are"
+Write-Host " skipped and left blank.)"
 Write-Host ""
 
 $slots = [ordered]@{ "Balanced" = 1010; "Performance" = 1011 }
@@ -70,28 +76,69 @@ $resolutions = Get-ChildItem $PSScriptRoot -Filter "*.mp4" | ForEach-Object {
 } | Sort-Object { [int]($_ -split 'x')[0] }
 
 # Frame counts. No --loop-file: it defeats --frames (mpv never quits a looping
-# file), so the high count must fit within one pass of the bundled clips (each
-# is ~90 s, ~2157 frames at 23.976 fps), with margin.
-$warmupFrames = 200
-$lowFrames    = 500
-$highFrames   = 1800
+# file), so counts must fit within one pass of the bundled clips (each is ~90 s,
+# ~2157 frames at 23.976 fps), with margin.
+$warmupFrames    = 120   # build the engine + fill the pipeline (throwaway)
+$probeFrames     = 240   # first timed point; also estimates the rate
+$windowSeconds   = 20    # target wall time of the measurement window
+$minWindowFrames = 200   # smallest probe->window gap (keeps slow cells accurate)
+$maxClipFrames   = 1900  # cap so a run always finishes within one clip pass
 
-function Invoke-MpvFrames($video, $vf, $n) {
-    # & with splatting quotes each arg correctly; -- guards the path so a clip
-    # name with spaces/dashes can't be parsed as more options or a stdin '-'.
-    $a = @(
+# Skip a cell once it can't sustain this many fps - well below the ~24 fps
+# real-time bar, so the exact number doesn't matter and isn't worth the wait.
+# Raising it skips more aggressively; lowering it measures slower hardware.
+$fpsFloor        = 6
+$decodeInitSec   = 12    # per-run startup allowance (decode/session init) on top of frames/fpsFloor
+$buildAllowSec   = 300   # warmup only: also covers a first-time TensorRT engine build
+
+# Kill a run once it has clearly fallen below $fpsFloor (frames it should have
+# finished by, plus a startup allowance). Warmup uses a fixed, larger budget so
+# a legitimate one-time engine build is never mistaken for a slow GPU.
+function Get-RunTimeout($frames) { [int]($decodeInitSec + $frames / $fpsFloor) }
+
+# Warmup budget: TensorRT may build an engine on first use (one-time, minutes),
+# so allow that; DirectML/NCNN never build, so hold warmup to the same fps floor
+# and skip a slow integrated GPU quickly instead of grinding through it.
+$warmupTimeout = if ($backend -match '^(?i:directml|ncnn)$') { Get-RunTimeout $warmupFrames } else { $buildAllowSec }
+
+function Invoke-MpvFrames($video, $vf, $n, $timeoutSec) {
+    $flags = @(
         '--process-instance=multi', '--auto-load-folder=no', '--untimed', '--no-audio',
         '--vo=null', '--keep-open=no', '--idle=no', '--sid=no', "--hwdec=$hwdec",
         '--no-resume-playback', '--save-position-on-quit=no', '--start=0',
-        "--vf=$vf", "--frames=$n", '--', $video
+        "--vf=$vf", "--frames=$n"
     )
-    # The DirectML/onnxruntime backend prints warnings to stderr; with
-    # ErrorActionPreference=Stop, PowerShell turns native stderr into a fatal
-    # error, so relax it around the call (all output is discarded anyway).
-    $eap = $ErrorActionPreference
-    $ErrorActionPreference = 'Continue'
-    try { return (Measure-Command { & $mpvnet @a *> $null }).TotalSeconds }
-    finally { $ErrorActionPreference = $eap }
+    # Every flag is space-free; only the clip path needs quoting and -- guards
+    # it. Building the command line by hand (vs Start-Process -ArgumentList)
+    # avoids the mangling of spaced/Unicode paths into a stdin '-', while still
+    # giving a Process handle we can time out and kill. Windows PowerShell 5.1
+    # has no ProcessStartInfo.ArgumentList, hence the explicit string.
+    $psi = New-Object System.Diagnostics.ProcessStartInfo
+    $psi.FileName               = $mpvnet
+    $psi.Arguments              = ($flags -join ' ') + ' -- "' + $video + '"'
+    $psi.UseShellExecute        = $false
+    $psi.CreateNoWindow         = $true
+    $psi.RedirectStandardOutput = $true
+    $psi.RedirectStandardError  = $true
+
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    $p  = [System.Diagnostics.Process]::Start($psi)
+    # Drain both pipes async so a chatty player can't deadlock on a full buffer
+    # while we wait (output is discarded). Using a Process instead of the call
+    # operator also means native stderr no longer trips ErrorActionPreference.
+    [void]$p.StandardOutput.ReadToEndAsync()
+    [void]$p.StandardError.ReadToEndAsync()
+
+    $exited = $p.WaitForExit([int]($timeoutSec * 1000))
+    $sw.Stop()
+    if (-not $exited) {
+        # Too slow - kill the player and any child (e.g. a trtexec build) by tree.
+        $eap = $ErrorActionPreference; $ErrorActionPreference = 'SilentlyContinue'
+        & taskkill /T /F /PID $p.Id *> $null
+        $ErrorActionPreference = $eap
+        [void]$p.WaitForExit(5000)
+    }
+    return [pscustomobject]@{ Seconds = $sw.Elapsed.TotalSeconds; TimedOut = (-not $exited) }
 }
 
 $table = @{}
@@ -115,12 +162,43 @@ foreach ($res in $resolutions) {
         $vf = $vfBase -replace 'slot=\d+', ("slot=" + $slots[$name])
         Write-Host -NoNewline ("{0,-12} {1,-10} " -f $name, $res)
         try {
-            [void](Invoke-MpvFrames $video $vf $warmupFrames)   # build engine + fill pipeline
-            $tLow  = Invoke-MpvFrames $video $vf $lowFrames
-            $tHigh = Invoke-MpvFrames $video $vf $highFrames
-            $dt = $tHigh - $tLow
+            # Warmup builds the engine + fills the pipeline. A timeout here means
+            # the GPU is below the floor (or, on TensorRT, a build that overran
+            # its budget) - either way not worth measuring.
+            $warm = Invoke-MpvFrames $video $vf $warmupFrames $warmupTimeout
+            if ($warm.TimedOut) {
+                $table[$name][$res] = ""
+                Write-Host "skipped (under $fpsFloor fps)" -ForegroundColor DarkYellow
+                continue
+            }
+
+            # Probe point: rough rate used both as the first timed point and to
+            # size the window run.
+            $probe = Invoke-MpvFrames $video $vf $probeFrames (Get-RunTimeout $probeFrames)
+            if ($probe.TimedOut) {
+                $table[$name][$res] = ""
+                Write-Host "skipped (under $fpsFloor fps)" -ForegroundColor DarkYellow
+                continue
+            }
+
+            # Size the window so its wall time is ~$windowSeconds at the probed
+            # rate (probe time includes startup, so this slightly under-shoots -
+            # fine). Floor the gap for accuracy, cap so the run fits one clip pass.
+            $fpsEst = $probeFrames / [math]::Max($probe.Seconds, 0.001)
+            $windowFrames = [math]::Max([int]($fpsEst * $windowSeconds), $minWindowFrames)
+            $windowFrames = [math]::Min($windowFrames, $maxClipFrames - $probeFrames)
+            $highFrames = $probeFrames + $windowFrames
+
+            $high = Invoke-MpvFrames $video $vf $highFrames (Get-RunTimeout $highFrames)
+            if ($high.TimedOut) {
+                $table[$name][$res] = ""
+                Write-Host "skipped (under $fpsFloor fps)" -ForegroundColor DarkYellow
+                continue
+            }
+
+            $dt = $high.Seconds - $probe.Seconds
             if ($dt -le 0) { throw "timing anomaly (dt=$([math]::Round($dt,3))s)" }
-            $fps = [math]::Round(($highFrames - $lowFrames) / $dt, 1)
+            $fps = [math]::Round(($highFrames - $probeFrames) / $dt, 1)
             $table[$name][$res] = $fps
             Write-Host "$fps fps" -ForegroundColor Green
         } catch {

--- a/BuildMpvUpscale2xAnimeJaNai/mpv-upscale-2x_animejanai/animejanai/benchmarks/benchmark.ps1
+++ b/BuildMpvUpscale2xAnimeJaNai/mpv-upscale-2x_animejanai/animejanai/benchmarks/benchmark.ps1
@@ -19,7 +19,8 @@
 # Sizing the window from the probe keeps each cell to about the same wall time
 # regardless of GPU speed. Each run is killed if it can't sustain $fpsFloor fps,
 # so hopelessly slow cells (well below real-time) are skipped instead of running
-# for many minutes; a skipped cell is left blank.
+# for many minutes; a skipped cell is written as -1, the sentinel the catalog
+# renders as a red "-" (well-below-real-time), distinct from a real measurement.
 
 $ErrorActionPreference = "Stop"
 $root        = Split-Path -Parent $PSScriptRoot       # animejanai/
@@ -66,8 +67,8 @@ Write-Host "mpv windows will open and close on their own. Do NOT close or click"
 Write-Host "them while the benchmark runs, or the results will be invalid."
 Write-Host "(TensorRT builds an engine per resolution on the first run, about a"
 Write-Host " minute each and cached afterward; the full sweep takes several minutes,"
-Write-Host " longer on slower GPUs. Cells too slow to be usable, under $fpsFloor fps, are"
-Write-Host " skipped and left blank.)"
+Write-Host " longer on slower GPUs. Cells too slow to be usable, under $fpsFloor fps,"
+Write-Host " are skipped and recorded as -1 (shown as '-' in the catalog).)"
 Write-Host ""
 
 $slots = [ordered]@{ "Balanced" = 1010; "Performance" = 1011 }
@@ -167,7 +168,7 @@ foreach ($res in $resolutions) {
             # its budget) - either way not worth measuring.
             $warm = Invoke-MpvFrames $video $vf $warmupFrames $warmupTimeout
             if ($warm.TimedOut) {
-                $table[$name][$res] = ""
+                $table[$name][$res] = -1   # sentinel: skipped, ran too slow (catalog renders "-")
                 Write-Host "skipped (under $fpsFloor fps)" -ForegroundColor DarkYellow
                 continue
             }
@@ -176,7 +177,7 @@ foreach ($res in $resolutions) {
             # size the window run.
             $probe = Invoke-MpvFrames $video $vf $probeFrames (Get-RunTimeout $probeFrames)
             if ($probe.TimedOut) {
-                $table[$name][$res] = ""
+                $table[$name][$res] = -1   # sentinel: skipped, ran too slow (catalog renders "-")
                 Write-Host "skipped (under $fpsFloor fps)" -ForegroundColor DarkYellow
                 continue
             }
@@ -191,7 +192,7 @@ foreach ($res in $resolutions) {
 
             $high = Invoke-MpvFrames $video $vf $highFrames (Get-RunTimeout $highFrames)
             if ($high.TimedOut) {
-                $table[$name][$res] = ""
+                $table[$name][$res] = -1   # sentinel: skipped, ran too slow (catalog renders "-")
                 Write-Host "skipped (under $fpsFloor fps)" -ForegroundColor DarkYellow
                 continue
             }

--- a/benchmark-proxy/src/index.js
+++ b/benchmark-proxy/src/index.js
@@ -26,6 +26,7 @@ const ROUTE = "/api/benchmarks";
 const MAX_BODY = 16 * 1024; // 16 KB
 const FPS_MIN = 0;
 const FPS_MAX = 100000;
+const SKIP_SENTINEL = -1; // "skipped, ran too slow to measure"; catalog renders "-"
 const ALLOWED_BACKENDS = new Set(["TensorRT", "DirectML", "ncnn"]);
 const RES_RE = /^\d{2,5}x\d{2,5}$/;
 const STR_MAX = 200;
@@ -88,6 +89,7 @@ function validate(b) {
   const templates = Object.keys(results);
   if (templates.length === 0 || templates.length > 16) return "invalid results";
   let cells = 0;
+  let measured = 0;
   for (const t of templates) {
     if (typeof t !== "string" || t.length > 40) return "invalid template name";
     const row = results[t];
@@ -95,11 +97,15 @@ function validate(b) {
     for (const res of Object.keys(row)) {
       if (!RES_RE.test(res)) return `invalid resolution: ${res}`;
       const fps = row[res];
-      if (typeof fps !== "number" || !isFinite(fps) || fps <= FPS_MIN || fps > FPS_MAX) return `invalid fps for ${res}`;
+      // -1 is the "skipped, too slow to measure" sentinel; any other value must
+      // be a real, positive fps.
+      if (typeof fps !== "number" || !isFinite(fps)) return `invalid fps for ${res}`;
+      if (fps !== SKIP_SENTINEL && (fps <= FPS_MIN || fps > FPS_MAX)) return `invalid fps for ${res}`;
+      if (fps > 0) measured++;
       if (++cells > 256) return "too many results";
     }
   }
-  if (cells === 0) return "no results";
+  if (measured === 0) return "no results"; // nothing actually ran; sentinels only
   return null;
 }
 

--- a/scripts/build-benchmarks.mjs
+++ b/scripts/build-benchmarks.mjs
@@ -19,18 +19,20 @@ function valid(s) {
   if (s.schema !== 1) return false;
   if (!ALLOWED_BACKENDS.has(s.backend)) return false;
   if (!s.results || typeof s.results !== "object") return false;
-  let cells = 0;
+  let measured = 0;
   for (const template of Object.keys(s.results)) {
     const row = s.results[template];
     if (!row || typeof row !== "object") return false;
     for (const res of Object.keys(row)) {
       if (!RES_RE.test(res)) return false;
       const fps = row[res];
-      if (typeof fps !== "number" || !isFinite(fps) || fps <= 0) return false;
-      cells++;
+      if (typeof fps !== "number" || !isFinite(fps)) return false;
+      // -1 = "skipped, too slow to measure" sentinel; otherwise a positive fps.
+      if (fps !== -1 && fps <= 0) return false;
+      if (fps > 0) measured++;
     }
   }
-  return cells > 0;
+  return measured > 0; // require at least one real measurement (sentinels alone don't count)
 }
 
 const files = (await readdir(SUBMISSIONS_DIR)).filter((f) => f.endsWith(".json"));

--- a/site/index.html
+++ b/site/index.html
@@ -45,7 +45,7 @@
   <h1>mpv-AnimeJaNai community benchmarks</h1>
   <p class="lede">Real playback fps of the AnimeJaNai upscaler across hardware.</p>
   <input class="search" id="q" placeholder="Filter by GPU, CPU, or OS..." />
-  <div class="legend">Headroom vs ~24 fps realtime:<span class="gs"></span>comfortable<span class="as"></span>borderline<span class="rs"></span>below realtime<span style="margin-left:18px"><b>-</b> = too slow to benchmark</span></div>
+  <div class="legend">Headroom vs ~24 fps realtime:<span class="gs"></span>comfortable<span class="as"></span>borderline<span class="rs"></span>below realtime</div>
 
   <div id="out"></div>
   <div id="empty" hidden>No benchmarks yet. Be the first: run the benchmark in the AnimeJaNai Manager and click <strong>Submit to Catalog</strong>.</div>

--- a/site/index.html
+++ b/site/index.html
@@ -31,11 +31,12 @@
     table.mini td:first-child, table.mini th:first-child { text-align: left; opacity: .85; padding-right: 22px; }
     table.mini td { border-top: 1px solid #8882; font-variant-numeric: tabular-nums; }
     td.fps { font-weight: 600; }
-    td.fps.g { color: #1a7f44; } td.fps.a { color: #9a6b00; } td.fps.r { color: #b42318; }
+    td.fps.g { color: #1a7f44; } td.fps.a { color: #9a6b00; } td.fps.r, td.fps.skip { color: #b42318; }
+    td.fps.skip { cursor: help; } td.fps.na { opacity: .3; font-weight: 400; }
     #empty { padding: 36px; text-align: center; opacity: .6; }
 
     @media (prefers-color-scheme: dark) {
-      td.fps.g { color: #6ee7a0; } td.fps.a { color: #e8c66a; } td.fps.r { color: #f08a8a; }
+      td.fps.g { color: #6ee7a0; } td.fps.a { color: #e8c66a; } td.fps.r, td.fps.skip { color: #f08a8a; }
       .legend .gs { background: #6ee7a0; } .legend .as { background: #e8c66a; } .legend .rs { background: #f08a8a; }
     }
   </style>
@@ -44,7 +45,7 @@
   <h1>mpv-AnimeJaNai community benchmarks</h1>
   <p class="lede">Real playback fps of the AnimeJaNai upscaler across hardware.</p>
   <input class="search" id="q" placeholder="Filter by GPU, CPU, or OS..." />
-  <div class="legend">Headroom vs ~24 fps realtime:<span class="gs"></span>comfortable<span class="as"></span>borderline<span class="rs"></span>below realtime</div>
+  <div class="legend">Headroom vs ~24 fps realtime:<span class="gs"></span>comfortable<span class="as"></span>borderline<span class="rs"></span>below realtime<span style="margin-left:18px"><b>-</b> = too slow to benchmark</span></div>
 
   <div id="out"></div>
   <div id="empty" hidden>No benchmarks yet. Be the first: run the benchmark in the AnimeJaNai Manager and click <strong>Submit to Catalog</strong>.</div>
@@ -73,9 +74,17 @@
     const ramText = (s) => !s.ram_mb ? "" : (s.ram_speed_mhz ? `${Math.round(s.ram_mb / 1024)}GB @ ${s.ram_speed_mhz}` : `${Math.round(s.ram_mb / 1024)}GB`);
     const vramText = (s) => s.vram_mb ? Math.round(s.vram_mb / 1024) + "GB VRAM" : "";
     const resShort = (r) => r.split("x")[1] + "p";
-    const fpsFmt = (v) => (v == null || v === "") ? "" : (Math.round(v * 10) / 10).toString();
+    const fpsFmt = (v) => (v == null || v === "" || v < 0) ? "" : (Math.round(v * 10) / 10).toString();
     // Headroom vs ~24 fps realtime: comfortable >=48 (~2x), borderline >=24, below realtime <24.
-    const fpsClass = (v) => (v == null || v === "") ? "" : (v >= 48 ? "g" : v >= 24 ? "a" : "r");
+    const fpsClass = (v) => (v == null || v === "" || v < 0) ? "" : (v >= 48 ? "g" : v >= 24 ? "a" : "r");
+    // One fps cell. -1 is the "skipped, too slow to benchmark" sentinel; a missing
+    // value means that machine didn't report this resolution at all.
+    const SKIP = -1;
+    function fpsCell(v) {
+      if (v === SKIP) return `<td class="fps skip" title="Skipped: ran too slow to benchmark (well below real-time)">-</td>`;
+      if (v == null || v === "") return `<td class="fps na" title="Not measured">&middot;</td>`;
+      return `<td class="fps ${fpsClass(v)}">${fpsFmt(v)}</td>`;
+    }
     const fmtDate = (iso) => { if (!iso) return ""; const d = new Date(iso); return isNaN(d) ? "" : d.toISOString().slice(0, 10); };
     const esc = (x) => String(x == null ? "" : x).replace(/[&<>"]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c]));
 
@@ -91,7 +100,15 @@
       if (s.submitted_by) bits.push(esc(s.submitted_by));
       return bits.join(" &middot; ");
     }
-    const best = (s) => (s.results.Balanced && s.results.Balanced["1920x1080"]) || (s.results.Performance && s.results.Performance["1920x1080"]) || 0;
+    // Sort key: best real 1080p fps across templates (ignores the -1 skip sentinel).
+    function best(s) {
+      let m = 0;
+      for (const t of Object.keys(s.results)) {
+        const v = s.results[t]["1920x1080"];
+        if (typeof v === "number" && v > m) m = v;
+      }
+      return m;
+    }
 
     fetch("./benchmarks.json", { cache: "no-store" })
       .then((r) => r.json())
@@ -101,6 +118,18 @@
           `${subs.length} submission${subs.length === 1 ? "" : "s"}` +
           (data.generated_at ? ` · updated ${fmtDate(data.generated_at)}` : "");
         if (subs.length === 0) { document.getElementById("empty").hidden = false; return; }
+
+        // Fixed table shape: every system shows the same template rows and
+        // resolution columns (the union across all submissions), so the catalog
+        // is predictable to read. A cell a given machine didn't run shows "-"
+        // (skipped, too slow) or a faint dot (not reported); see fpsCell.
+        const ALL_TPL = [...new Set(subs.flatMap((s) => Object.keys(s.results)))]
+          .sort((a, b) => {
+            const ia = TEMPLATE_ORDER.indexOf(a), ib = TEMPLATE_ORDER.indexOf(b);
+            return (ia < 0 ? 99 : ia) - (ib < 0 ? 99 : ib) || a.localeCompare(b);
+          });
+        const ALL_RES = [...new Set(subs.flatMap((s) => Object.values(s.results).flatMap((r) => Object.keys(r))))]
+          .sort((a, b) => (+a.split("x")[0]) - (+b.split("x")[0]));
 
         const q = document.getElementById("q");
         function render() {
@@ -119,18 +148,12 @@
             if (sys[0].gpu_power_w) tags.push(sys[0].gpu_power_w + "W");
             html += `<div class="gpu">${esc(gpu)}<span class="cnt">${tags.join(" · ")}</span></div>`;
             for (const s of sys) {
-              // Per-system column set (its own resolutions/templates), kept simple and local.
-              const tpls = Object.keys(s.results).sort((a, b) => {
-                const ia = TEMPLATE_ORDER.indexOf(a), ib = TEMPLATE_ORDER.indexOf(b);
-                return (ia < 0 ? 99 : ia) - (ib < 0 ? 99 : ib) || a.localeCompare(b);
-              });
-              const resSet = new Set();
-              tpls.forEach((t) => Object.keys(s.results[t]).forEach((r) => resSet.add(r)));
-              const res = [...resSet].sort((a, b) => (+a.split("x")[0]) - (+b.split("x")[0]));
+              // Same fixed columns/rows for every system (see ALL_RES/ALL_TPL).
               html += `<div class="sys"><div class="specs">${specLine(s)}</div>`;
-              html += `<table class="mini"><tr><th>fps</th>${res.map((r) => `<th>${resShort(r)}</th>`).join("")}</tr>`;
-              for (const t of tpls) {
-                html += `<tr><td>${esc(t)}</td>${res.map((r) => { const v = s.results[t][r]; return `<td class="fps ${fpsClass(v)}">${fpsFmt(v)}</td>`; }).join("")}</tr>`;
+              html += `<table class="mini"><tr><th>fps</th>${ALL_RES.map((r) => `<th>${resShort(r)}</th>`).join("")}</tr>`;
+              for (const t of ALL_TPL) {
+                const row = s.results[t] || {};
+                html += `<tr><td>${esc(t)}</td>${ALL_RES.map((r) => fpsCell(row[r])).join("")}</tr>`;
               }
               html += `</table></div>`;
             }


### PR DESCRIPTION
Follow-up to the DirectML `hwdec` fix. Two parts.

## 1. Time-bounded benchmark, skip below-real-time cells
On slow GPUs (Intel Iris Xe via DirectML) higher-res cells ran for many minutes. Replaced the fixed low/high frame counts with a short **probe** that estimates the rate, then a **window** run sized to a target wall time (`$windowSeconds`); the two points still subtract to cancel startup. Each run launches via `System.Diagnostics.Process` (Windows PowerShell 5.1 compatible) and is killed once it can't sustain `$fpsFloor` fps (default **6**, well under ~24 fps real-time). Fast GPUs are unaffected (the clip-length cap means they finish well under the target); only slow cells get cut.

## 2. Skip sentinel + fixed-column catalog
Skipped cells record **`-1`** (the too-slow sentinel) instead of being omitted, so the catalog renders them explicitly instead of inferring from absence (which would mislabel a future-added resolution on old submissions).

- **proxy + aggregator:** accept `fps === -1` alongside real values, but still require >=1 positive measurement (a machine that ran nothing has nothing to submit).
- **site:** every system now shows the **same fixed template rows + resolution columns** (union across all submissions) -> predictable, easy to read. `-1` -> red **`-`** with a "too slow to benchmark" hover tooltip; a resolution a machine never reported -> faint dot. Sort key ignores the sentinel.
- **Manager:** no change; its parser already passes `-1` through.

## Deploy notes
- `benchmark.ps1` ships in the package overlay (next package build).
- **The Cloudflare Worker must be redeployed** (`wrangler deploy`) for the proxy to accept `-1`.
- The site redeploys via `benchmarks.yml` on merge to main.