### PR TITLE
site: strip WDDM prefix for AMD driver versions too

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -89,10 +89,13 @@
     const esc = (x) => String(x == null ? "" : x).replace(/[&<>"]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c]));
 
     // WMI reports the raw Windows/WDDM driver string (e.g. 32.0.16.1047), which no
-    // end user recognizes. Show the vendor's marketing version instead:
-    //   NVIDIA  32.0.16.1047 -> 610.47   (last 5 digits, dot before the last two)
-    //   Intel   32.0.101.6737 -> 101.6737 (drop the leading WDDM major.minor)
-    //   AMD/other: the WMI string doesn't map to a marketing number, so leave raw.
+    // end user recognizes. Show the vendor's recognizable version instead:
+    //   NVIDIA  32.0.16.1047  -> 610.47    (last 5 digits, dot before the last two)
+    //   Intel   32.0.101.6737 -> 101.6737  (drop the leading WDDM major.minor)
+    //   AMD     31.0.24033.1003 -> 24033.1003 (same prefix strip = the "driver
+    //           store version" Adrenalin shows; not the 24.12.1 marketing name,
+    //           which isn't derivable from this string without a lookup table)
+    //   other:  leave raw.
     // The raw value stays in the data and is shown on hover.
     function driverPretty(s) {
       const d = (s.driver || "").trim();
@@ -103,8 +106,9 @@
         const digits = d.replace(/\D/g, "");
         if (digits.length >= 5) { const t = digits.slice(-5); return t.slice(0, 3) + "." + t.slice(3); }
       }
-      const isIntel = /intel|iris|\barc\b|\buhd\b|hd graphics/i.test(gpu) || /^\d+\.\d+\.101\./.test(d);
-      if (isIntel) { const m = d.match(/^\d+\.\d+\.(.+)$/); if (m) return m[1]; }
+      // Intel and AMD: drop the WDDM major.minor to get the tail their own tools show.
+      const isIntelOrAmd = /intel|iris|\barc\b|\buhd\b|hd graphics|amd|radeon|\brx\b/i.test(gpu) || /^\d+\.\d+\.(101|\d{5})\./.test(d);
+      if (isIntelOrAmd) { const m = d.match(/^\d+\.\d+\.(.+)$/); if (m) return m[1]; }
       return d;
     }
 


### PR DESCRIPTION
Follow-up that missed the PR #81 merge window.

PR #81 prettified NVIDIA/Intel driver strings. This extends the same prefix-strip to AMD: `31.0.24033.1003` -> `24033.1003` (the "driver store version" Adrenalin shows, more recognizable than the raw WMI string). It's not the `24.12.1` marketing name, which has no formula from this string without a lookup table. Unknown vendors still fall through to raw. Display-only; raw kept on hover.