### PR TITLE
conf: ship default_slot=1002 (show Balanced as the default)

### DIFF
--- a/BuildMpvUpscale2xAnimeJaNai/mpv-upscale-2x_animejanai/animejanai/animejanai.conf
+++ b/BuildMpvUpscale2xAnimeJaNai/mpv-upscale-2x_animejanai/animejanai/animejanai.conf
@@ -2,6 +2,7 @@
 config_version=3
 backend=TensorRT
 logging=yes
+default_slot=1002
 [slot_1]
 profile_name=New Profile
 [slot_2]


### PR DESCRIPTION
On a fresh install the bundled `animejanai.conf` had no `default_slot`, so the Manager showed *no* default profile selected even though the `vf` line's baked-in slot 1002 (Balanced) was actively upscaling - confusing UI. This ships `default_slot=1002` so Balanced appears as the default and the UI matches what's actually playing. `backend.lua` re-applies 1002 on first file (no-op vs the baked-in slot). Existing installs are unaffected (conf already present); fresh-install only.