### PR TITLE
Bump aji pin to v0.4.0 (multi-GPU CUDA kernels)

### DIFF
--- a/BuildMpvUpscale2xAnimeJaNai/Program.cs
+++ b/BuildMpvUpscale2xAnimeJaNai/Program.cs
@@ -21,7 +21,7 @@ using static Downloader;
 // NOTE: v16.test1 is vs-mlrt's TRT 11 PRE-release - recheck for a stable
 // v16 tag before cutting the package release.
 const string VsMlrtCudaVersion    = "v16.test1";
-const string AjiVersion           = "v0.2.0";       // github.com/the-database/animejanai-inference release tag (ABI v7, pipelined)
+const string AjiVersion           = "v0.4.0";       // github.com/the-database/animejanai-inference release tag (ABI v7; multi-GPU kernels - fixes sm120-only build)
 const string SevenZipVersion      = "2501";         // 7-zip "extra" standalone console version
 const string MpvNetVersion        = "v7.1.2.0";
 const string ManagerVersion       = "0.2.4";        // github.com/the-database/AnimeJaNaiConfEditor release tag (AnimeJaNai Manager)


### PR DESCRIPTION
Points the builder at aji `v0.4.0`, which compiles aji's CUDA pre/post kernels for all supported architectures (sm75/80/86/89/90/100/120 + PTX) instead of `native` (build-machine GPU only). This fixes the silent-passthrough bug where the shipped sm120-only build failed with `no kernel image is available for execution on the device` on every non-RTX-5090 NVIDIA GPU (e.g. the 4090 benchmark reporting 687 fps = decode-only).

ABI is unchanged - the `aji.h` delta from v0.2.0 to v0.4.0 is a comment only - so the mpv filter and libmpv need no rebuild; this is purely the asset pin. v0.4.0 also carries the offline-encoder P010 zero-copy work, which doesn't affect the player's runtime paths (verified no-regression on same-format output).

After merge: rebuild the 3.4.0 package (deploy), then re-test on a non-5090 NVIDIA GPU - upscaling should now run and the benchmark should report real fps.