### PR TITLE
Fix aji pin back to v0.4.0 (v0.4.1 deleted)

### DIFF
--- a/BuildMpvUpscale2xAnimeJaNai/Program.cs
+++ b/BuildMpvUpscale2xAnimeJaNai/Program.cs
@@ -21,7 +21,7 @@ using static Downloader;
 // NOTE: v16.test1 is vs-mlrt's TRT 11 PRE-release - recheck for a stable
 // v16 tag before cutting the package release.
 const string VsMlrtCudaVersion    = "v16.test1";
-const string AjiVersion           = "v0.4.1";       // github.com/the-database/animejanai-inference release tag (multi-GPU kernels + CUDA graphs off by default)
+const string AjiVersion           = "v0.4.0";       // github.com/the-database/animejanai-inference release tag (multi-GPU kernels + P010; CUDA graphs ON)
 const string SevenZipVersion      = "2501";         // 7-zip "extra" standalone console version
 const string MpvNetVersion        = "v7.1.2.0";
 const string ManagerVersion       = "0.2.4";        // github.com/the-database/AnimeJaNaiConfEditor release tag (AnimeJaNai Manager)


### PR DESCRIPTION
`main` was left pinning aji **v0.4.1** — PR #86 merged before the revert-to-v0.4.0 commit was pushed (merge race), and v0.4.1 (the graphs-off release) has since been **deleted**. A package build from main would 404 on `aji-windows-x64.zip`. This pins back to **v0.4.0** (graphs on; multi-GPU kernels + P010). Required before the 3.4.0 package rebuild.