### PR TITLE
Bump Manager pin to 0.3.0 (repo renamed to AnimeJaNaiManager)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,10 +8,10 @@
 # Runtime log written on every play by animejanai_core.write_current_log_empty
 BuildMpvUpscale2xAnimeJaNai/mpv-upscale-2x_animejanai/animejanai/core/currentanimejanai.log
 
-# AnimeJaNaiConfEditor binaries are downloaded at build time (InstallAnimeJaNaiConfEditor),
+# AnimeJaNaiManager binaries are downloaded at build time (InstallAnimeJaNaiManager),
 # not committed. Guard against accidentally re-tracking them in the overlay.
-/BuildMpvUpscale2xAnimeJaNai/mpv-upscale-2x_animejanai/animejanai/AnimeJaNaiConfEditor.exe
-/BuildMpvUpscale2xAnimeJaNai/mpv-upscale-2x_animejanai/animejanai/AnimeJaNaiConfEditor.pdb
+/BuildMpvUpscale2xAnimeJaNai/mpv-upscale-2x_animejanai/animejanai/AnimeJaNaiManager.exe
+/BuildMpvUpscale2xAnimeJaNai/mpv-upscale-2x_animejanai/animejanai/AnimeJaNaiManager.pdb
 /BuildMpvUpscale2xAnimeJaNai/mpv-upscale-2x_animejanai/animejanai/av_libglesv2.dll
 /BuildMpvUpscale2xAnimeJaNai/mpv-upscale-2x_animejanai/animejanai/libHarfBuzzSharp.dll
 /BuildMpvUpscale2xAnimeJaNai/mpv-upscale-2x_animejanai/animejanai/libSkiaSharp.dll

--- a/BuildMpvUpscale2xAnimeJaNai/Program.cs
+++ b/BuildMpvUpscale2xAnimeJaNai/Program.cs
@@ -24,7 +24,7 @@ const string VsMlrtCudaVersion    = "v16.test1";
 const string AjiVersion           = "v0.4.0";       // github.com/the-database/animejanai-inference release tag (multi-GPU kernels + P010; CUDA graphs ON)
 const string SevenZipVersion      = "2501";         // 7-zip "extra" standalone console version
 const string MpvNetVersion        = "v7.1.2.0";
-const string ManagerVersion       = "0.2.4";        // github.com/the-database/AnimeJaNaiConfEditor release tag (AnimeJaNai Manager)
+const string ManagerVersion       = "0.3.0";        // github.com/the-database/AnimeJaNaiManager release tag (AnimeJaNai Manager)
 
 // DirectML backend runtime (backend=DirectML in animejanai.conf). These are
 // the last DirectML-flavored releases: Microsoft moved DML to sustained
@@ -352,7 +352,7 @@ void GenerateInputConf()
 async Task InstallAnimeJaNaiManager()
 {
     Console.WriteLine("Downloading AnimeJaNai Manager...");
-    var downloadUrl = $"https://github.com/the-database/AnimeJaNaiConfEditor/releases/download/{ManagerVersion}/AnimeJaNaiManager-portable-x64.zip";
+    var downloadUrl = $"https://github.com/the-database/AnimeJaNaiManager/releases/download/{ManagerVersion}/AnimeJaNaiManager-portable-x64.zip";
     var targetPath = Path.GetFullPath("AnimeJaNaiManager-portable-x64.zip");
     await DownloadFileAsync(downloadUrl, targetPath, (progress) =>
     {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,10 +4,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What this repo is
 
-This repo does **not** contain the mpv player or the AnimeJaNaiConfEditor. It contains:
+This repo does **not** contain the mpv player or the AnimeJaNai Manager. It contains:
 
-1. **`BuildMpvUpscale2xAnimeJaNai/`** — a C# console app whose only job is to download mpv.net, Portable VapourSynth, vs-mlrt (TensorRT/CUDA), RIFE models, yt-dlp, AnimeJaNaiConfEditor, and various VS plugins, then layer the runtime files in `BuildMpvUpscale2xAnimeJaNai/mpv-upscale-2x_animejanai/` on top to produce the redistributable `mpv-upscale-2x_animejanai-v<version>/` directory.
-2. **`BuildMpvUpscale2xAnimeJaNai/mpv-upscale-2x_animejanai/`** — the *runtime overlay*: the Python/VapourSynth scripts (`animejanai/core/`), ONNX models (`animejanai/onnx/`), per-slot `.vpy` shims (`animejanai/profiles/`), default `animejanai.conf`, and mpv config (`portable_config/`). `AnimeJaNaiConfEditor.exe` is **not** in the overlay — it's downloaded at build time from its own repo's release (see below).
+1. **`BuildMpvUpscale2xAnimeJaNai/`** — a C# console app whose only job is to download mpv.net, Portable VapourSynth, vs-mlrt (TensorRT/CUDA), RIFE models, yt-dlp, AnimeJaNai Manager, and various VS plugins, then layer the runtime files in `BuildMpvUpscale2xAnimeJaNai/mpv-upscale-2x_animejanai/` on top to produce the redistributable `mpv-upscale-2x_animejanai-v<version>/` directory.
+2. **`BuildMpvUpscale2xAnimeJaNai/mpv-upscale-2x_animejanai/`** — the *runtime overlay*: the Python/VapourSynth scripts (`animejanai/core/`), ONNX models (`animejanai/onnx/`), per-slot `.vpy` shims (`animejanai/profiles/`), default `animejanai.conf`, and mpv config (`portable_config/`). `AnimeJaNaiManager.exe` is **not** in the overlay — it's downloaded at build time from its own repo's release (see below).
 
 A user-facing release is the C# app's output, not anything in source form.
 
@@ -77,17 +77,17 @@ The chain that runs when a user plays a video:
 
 - Hardcodes the built-in slots (`1001`–`1003`, `1010`–`1011`) as Python dicts.
 - Parses the user's `.conf` with `configparser`, then *flattens* keys of the form `chain_<n>_model_<m>_<field>` into nested `{slot: {chain_n: {models: [...], ...}}}` dicts. Any new chain/model field must be read explicitly in `read_config_by_chain` / `read_config_by_chain_model` — there is no generic schema.
-- Applies `[global]` migrations/overrides via `_migrate_global` (schema `config_version`, default-fingerprinting) and `_apply_default_preset`. The latter is per-profile: `[global] quality_preset` / `balanced_preset` / `performance_preset` (`standard | sharp`, absent ⇒ standard) independently switch the HD models in built-in slots `1001`/`1002`/`1003` from `…_HD_V3.1_…` to `…_HD_V3.1Sharp1_…`. The AnimeJaNaiConfEditor writes these keys (per-profile Standard/Sharp toggle); keep the two in sync.
+- Applies `[global]` migrations/overrides via `_migrate_global` (schema `config_version`, default-fingerprinting) and `_apply_default_preset`. The latter is per-profile: `[global] quality_preset` / `balanced_preset` / `performance_preset` (`standard | sharp`, absent ⇒ standard) independently switch the HD models in built-in slots `1001`/`1002`/`1003` from `…_HD_V3.1_…` to `…_HD_V3.1Sharp1_…`. The AnimeJaNai Manager writes these keys (per-profile Standard/Sharp toggle); keep the two in sync.
 
 ### Stats overlay
 
 `Ctrl+J` in mpv invokes `portable_config/scripts/animejanaistats.lua`, which simply reads `animejanai/core/currentanimejanai.log`. That file is rewritten every run by `write_current_log()` in `animejanai_core.py` — append to `current_logger_info` / `current_logger_steps` to surface info to the user.
 
-### `AnimeJaNaiConfEditor.exe`
+### `AnimeJaNaiManager.exe`
 
-Downloaded at build time by `InstallAnimeJaNaiConfEditor()` in `Program.cs` from a GitHub release of its source repo (`github.com/the-database/AnimeJaNaiConfEditor`), pinned via the `ConfEditorVersion` constant. The release asset `AnimeJaNaiConfEditor-portable-x64.zip` (the `.exe` + native Avalonia DLLs `libSkiaSharp.dll`/`av_libglesv2.dll`/`libHarfBuzzSharp.dll`) is extracted into `animejanai/`, so it ends up next to the overlay's own `animejanai.conf` and `onnx/`. It edits `animejanai.conf` and is launched by mpv via `Ctrl+E`.
+Downloaded at build time by `InstallAnimeJaNaiManager()` in `Program.cs` from a GitHub release of its source repo (`github.com/the-database/AnimeJaNaiManager`), pinned via the `ManagerVersion` constant. The release asset `AnimeJaNaiManager-portable-x64.zip` (the `.exe` + native Avalonia DLLs `libSkiaSharp.dll`/`av_libglesv2.dll`/`libHarfBuzzSharp.dll`) is extracted into `animejanai/`, so it ends up next to the overlay's own `animejanai.conf` and `onnx/`. It edits `animejanai.conf` and is launched by mpv via `Ctrl+E`.
 
-To ship a new editor build: run the editor repo's manual `Release` workflow (Actions → Run workflow, enter the version) to cut a release, then bump `ConfEditorVersion` here to match. The binaries are **not** committed to this repo (they're `.gitignore`d as a guard).
+To ship a new editor build: run the editor repo's manual `Release` workflow (Actions → Run workflow, enter the version) to cut a release, then bump `ManagerVersion` here to match. The binaries are **not** committed to this repo (they're `.gitignore`d as a guard).
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ shipped keybindings are refreshed.)
 
 ## Customizing Profiles and Other Settings
 
-Upscaling can be further customized using the AnimeJaNaiConfEditor which can be launched by pressing `ctrl+E` from mpvnet. The editor allows the setup of up to 9 custom slots and also the use of custom chains, conditional settings based on video resolution and framerate, downscaling to improve performance, and more. The default upscaling profile can also be set using the conf editor. 
+Upscaling can be further customized using the AnimeJaNai Manager which can be launched by pressing `ctrl+E` from mpvnet. The Manager allows the setup of up to 9 custom slots and also the use of custom chains, conditional settings based on video resolution and framerate, downscaling to improve performance, and more. The default upscaling profile can also be set in the Manager. 
 
 ![image](https://github.com/the-database/mpv-upscale-2x_animejanai/assets/25811902/76a8db5b-8c67-4b0c-911a-9b02598fb37a)
 

--- a/benchmark-proxy/README.md
+++ b/benchmark-proxy/README.md
@@ -23,7 +23,7 @@ as a Worker secret — never in the desktop app and never in this repo.
 ## Endpoint
 
 `POST /api/benchmarks` — JSON body (schema 1). The Manager builds this; see
-`AnimeJaNaiConfEditor` → `Services/BenchmarkSubmission.cs`.
+`AnimeJaNaiManager` → `Services/BenchmarkSubmission.cs`.
 
 ```json
 {


### PR DESCRIPTION
The editor repo was renamed `AnimeJaNaiConfEditor` → `AnimeJaNaiManager`. Updates the Manager release download URL in `Program.cs` to the new repo name (so it doesn't depend on GitHub's rename redirect) and bumps `ManagerVersion` 0.2.4 → **0.3.0** (the Avalonia 12 build). Asset name is unchanged (`AnimeJaNaiManager-portable-x64.zip`); verified the 0.3.0 release carries it.