### PR TITLE
Bump Manager pin to 0.3.1

### DIFF
--- a/BuildMpvUpscale2xAnimeJaNai/Program.cs
+++ b/BuildMpvUpscale2xAnimeJaNai/Program.cs
@@ -24,7 +24,7 @@ const string VsMlrtCudaVersion    = "v16.test1";
 const string AjiVersion           = "v0.4.0";       // github.com/the-database/animejanai-inference release tag (multi-GPU kernels + P010; CUDA graphs ON)
 const string SevenZipVersion      = "2501";         // 7-zip "extra" standalone console version
 const string MpvNetVersion        = "v7.1.2.0";
-const string ManagerVersion       = "0.3.0";        // github.com/the-database/AnimeJaNaiManager release tag (AnimeJaNai Manager)
+const string ManagerVersion       = "0.3.1";        // github.com/the-database/AnimeJaNaiManager release tag (AnimeJaNai Manager)
 
 // DirectML backend runtime (backend=DirectML in animejanai.conf). These are
 // the last DirectML-flavored releases: Microsoft moved DML to sustained


### PR DESCRIPTION
Bumps `ManagerVersion` 0.3.0 -> 0.3.1 in the package builder (`Program.cs:27`). The builder downloads `AnimeJaNaiManager-portable-x64.zip` from the `0.3.1` tag of `the-database/AnimeJaNaiManager` at build time.

**Blocker:** the `0.3.1` release is not published yet (latest is 0.3.0). Publish the `0.3.1` release with the `AnimeJaNaiManager-portable-x64.zip` asset before the next package build, or the build will 404 on download.