### PR TITLE
installer: preserve user files on reinstall-over

### DIFF
--- a/installer/animejanai.iss
+++ b/installer/animejanai.iss
@@ -62,7 +62,20 @@ Name: "assocvideo"; Description: "Associate common &video file types with {#AppN
 ; can run it for GPU detection during the wizard; exclude it from the wildcard to
 ; avoid listing it twice.
 Source: "{#SourceDir}\{#UpdaterExe}"; DestDir: "{app}"; Flags: ignoreversion
-Source: "{#SourceDir}\*"; DestDir: "{app}"; Excludes: "{#UpdaterExe}"; Flags: recursesubdirs createallsubdirs ignoreversion
+
+; User-owned files: write the shipped default only on a FRESH install; never clobber an
+; existing user copy on a reinstall-over (mirrors the updater's manifest "user_preserve"
+; deny-list in BuildMpvUpscale2xAnimeJaNai/Program.cs). Without onlyifdoesntexist the
+; wildcard below would reset the user's profiles, keybindings, mpv settings, and mpv.net
+; state (last-played video / window / volume) to the package defaults on every reinstall.
+; Keep this list in sync with that manifest's user_preserve array.
+Source: "{#SourceDir}\animejanai\animejanai.conf";       DestDir: "{app}\animejanai";       Flags: onlyifdoesntexist
+Source: "{#SourceDir}\portable_config\mpv.conf";         DestDir: "{app}\portable_config";  Flags: onlyifdoesntexist
+Source: "{#SourceDir}\portable_config\input.conf";       DestDir: "{app}\portable_config";  Flags: onlyifdoesntexist
+Source: "{#SourceDir}\portable_config\saved-props.json"; DestDir: "{app}\portable_config";  Flags: onlyifdoesntexist
+Source: "{#SourceDir}\portable_config\settings.xml";     DestDir: "{app}\portable_config";  Flags: onlyifdoesntexist
+
+Source: "{#SourceDir}\*"; DestDir: "{app}"; Excludes: "{#UpdaterExe},animejanai\animejanai.conf,portable_config\mpv.conf,portable_config\input.conf,portable_config\saved-props.json,portable_config\settings.xml"; Flags: recursesubdirs createallsubdirs ignoreversion
 
 [Icons]
 Name: "{group}\{#AppName}"; Filename: "{app}\{#PlayerExe}"


### PR DESCRIPTION
## Problem

Reinstalling by running the Setup .exe over an existing install **resets the user's config and mpv.net state** (last-played video forgotten, resume-on-launch stops working, custom upscale profiles/keybindings lost). Upgrading in-place via Ctrl+U does *not* do this.

**Root cause:** `[Files]` line 65, `Source: "{#SourceDir}\\*"` with `ignoreversion`, copies every shipped file over the existing install. The in-place updater honors the manifest's `user_preserve` deny-list (`BuildMpvUpscale2xAnimeJaNai/Program.cs`) and skips these files; the installer didn't, so it clobbered them with the package defaults.

Shipped files that are also `user_preserve` and were being reset:
- `animejanai/animejanai.conf` - custom upscale profiles / `default_slot`
- `portable_config/mpv.conf` - user mpv settings
- `portable_config/input.conf` - keybindings + managed block
- `portable_config/saved-props.json` - speed/volume/mute
- `portable_config/settings.xml` - `RecentFiles` (last video), window, volume

## Fix

Give those five files their own `[Files]` entries with `onlyifdoesntexist` and exclude them from the wildcard, so the shipped default is written only on a **fresh** install and an existing user copy is never overwritten - mirroring the updater's `user_preserve` behavior. Everything else (binaries, scripts, shaders, the managed `*-animejanai.conf` defaults) still updates via the wildcard. `mpv.conf` only `include`s the refreshed `mpv-animejanai.conf`, so managed mpv defaults still update.

`watch_later/` (per-file resume positions) is runtime-only and already survives a reinstall-over. Uninstall behavior is unchanged.

## Known limitation

`input.conf`'s embedded managed keybinding block won't be refreshed by an installer-reinstall (preserved wholesale); the Ctrl+U updater still syncs it. Far preferable to wiping user keybindings. Optional follow-up: an updater `--sync-config` mode invoked post-install.

## Verification (needs a Windows install; can't run here)
1. Fresh install -> all five files present with seed contents.
2. Modify `animejanai.conf`/`mpv.conf`, play videos (populate `RecentFiles` + `watch_later`), run Setup over it -> those five files unchanged; binaries/scripts/`mpv-animejanai.conf` refreshed.
3. After reinstall, player reopens last video and resumes position.