### PR TITLE
Benchmark: AMD Radeon RX 7900 XTX (DirectML)

### DIFF
--- a/data/benchmarks/submissions/39ef3568-0236-48bb-80d5-c897aa6f60e0.json
+++ b/data/benchmarks/submissions/39ef3568-0236-48bb-80d5-c897aa6f60e0.json
@@ -1,0 +1,34 @@
+{
+  "schema": 1,
+  "id": "39ef3568-0236-48bb-80d5-c897aa6f60e0",
+  "submitted_at": "2026-06-16T18:03:08.051Z",
+  "app_version": "3.4.0",
+  "backend": "DirectML",
+  "gpu": "AMD Radeon RX 7900 XTX",
+  "cpu": "AMD Ryzen 7 7800X3D 8-Core Processor",
+  "cpu_mhz": 4201,
+  "cpu_cores": 8,
+  "cpu_threads": 16,
+  "ram_mb": 32343,
+  "ram_speed_mhz": 5600,
+  "os": "Microsoft Windows 10.0.26200",
+  "driver": "32.0.22021.1009",
+  "results": {
+    "Balanced": {
+      "480x360": 603.5,
+      "640x480": 402.5,
+      "768x576": 302.4,
+      "1280x720": 175.5,
+      "1920x1080": 65.5
+    },
+    "Performance": {
+      "480x360": 602.8,
+      "640x480": 613,
+      "768x576": 604.5,
+      "1280x720": 302.2,
+      "1920x1080": 125.2
+    }
+  },
+  "submitted_by": "",
+  "note": ""
+}


### PR DESCRIPTION
Automated community benchmark submission.

- GPU: AMD Radeon RX 7900 XTX
- Backend: DirectML
- App: 3.4.0
- OS: Microsoft Windows 10.0.26200
- Submitted by: (anonymous)

Merging publishes it to the catalog.