### PR TITLE
Fix benchmark catalog GPU metadata handling

### DIFF
--- a/BuildMpvUpscale2xAnimeJaNai/mpv-upscale-2x_animejanai/animejanai/benchmarks/benchmark.ps1
+++ b/BuildMpvUpscale2xAnimeJaNai/mpv-upscale-2x_animejanai/animejanai/benchmarks/benchmark.ps1
@@ -738,6 +738,15 @@ foreach ($res in $resolutions) {
 
 Remove-Item $clipRoot -Recurse -Force -ErrorAction SilentlyContinue
 
+function Format-ResultCell($value) {
+    if ($null -eq $value) { return "" }
+    if ($value -is [string]) { return $value }
+    if ($value -is [ValueType]) {
+        return ([double]$value).ToString("0.##", [System.Globalization.CultureInfo]::InvariantCulture)
+    }
+    return [string]$value
+}
+
 # Markdown table - same shape the Submit-to-Catalog parser expects.
 $lines = @()
 $lines += "AnimeJaNai playback benchmark - backend: $backend"
@@ -745,7 +754,7 @@ $lines += ""
 $lines += "|fps|" + ($resolutions -join "|") + "|"
 $lines += "|-|" + (($resolutions | ForEach-Object { "-" }) -join "|") + "|"
 foreach ($name in $slots.Keys) {
-    $row = $resolutions | ForEach-Object { $table[$name][$_] }
+    $row = $resolutions | ForEach-Object { Format-ResultCell $table[$name][$_] }
     if (($row | Where-Object { $_ -ne $null -and $_ -ne "" }).Count -eq 0) { continue }
     $lines += "|$name|" + ($row -join "|") + "|"
 }

--- a/benchmark-proxy/src/index.js
+++ b/benchmark-proxy/src/index.js
@@ -75,6 +75,9 @@ function validate(b) {
   for (const k of ["app_version", "gpu", "cpu", "os", "driver", "submitted_by"]) {
     if (b[k] != null && (typeof b[k] !== "string" || b[k].length > STR_MAX)) return `invalid ${k}`;
   }
+  if (b.backend === "TensorRT" && !isNvidiaGpuName(b.gpu)) {
+    return "TensorRT submissions must identify the NVIDIA GPU";
+  }
   if (b.note != null && (typeof b.note !== "string" || b.note.length > NOTE_MAX)) return "invalid note";
   if (b.vram_mb != null && (typeof b.vram_mb !== "number" || !isFinite(b.vram_mb) || b.vram_mb < 0 || b.vram_mb > 4194304)) return "invalid vram_mb";
   if (b.gpu_power_w != null && (typeof b.gpu_power_w !== "number" || !isFinite(b.gpu_power_w) || b.gpu_power_w < 0 || b.gpu_power_w > 10000)) return "invalid gpu_power_w";
@@ -107,6 +110,10 @@ function validate(b) {
   }
   if (measured === 0) return "no results"; // nothing actually ran; sentinels only
   return null;
+}
+
+function isNvidiaGpuName(value) {
+  return /nvidia|geforce|\brtx\b|\bgtx\b|quadro|titan/i.test(String(value || ""));
 }
 
 // Replace control characters and angle brackets with spaces, then collapse

--- a/scripts/build-benchmarks.mjs
+++ b/scripts/build-benchmarks.mjs
@@ -13,6 +13,34 @@ const OUT = path.join(repoRoot, "site", "benchmarks.json");
 
 const ALLOWED_BACKENDS = new Set(["TensorRT", "DirectML", "ncnn"]);
 const RES_RE = /^\d{2,5}x\d{2,5}$/;
+const GPU_SPECS = [
+  [/Radeon\s+RX\s+9070\s+XT\b/i, 16 * 1024, 304],
+  [/Radeon\s+RX\s+9070\s+GRE\b/i, 12 * 1024, 220],
+  [/Radeon\s+RX\s+9070\b/i, 16 * 1024, 220],
+  [/Radeon\s+RX\s+9060\s+XT\b/i, null, 160],
+  [/Radeon\s+RX\s+7900\s+XTX\b/i, 24 * 1024, 355],
+  [/Radeon\s+RX\s+7900\s+XT\b/i, 20 * 1024, 315],
+  [/Radeon\s+RX\s+7900\s+GRE\b/i, 16 * 1024, 260],
+  [/Radeon\s+RX\s+7800\s+XT\b/i, 16 * 1024, 263],
+  [/Radeon\s+RX\s+7700\s+XT\b/i, 12 * 1024, 245],
+  [/Radeon\s+RX\s+7600\s+XT\b/i, 16 * 1024, 165],
+  [/Radeon\s+RX\s+7600\b/i, 8 * 1024, 165],
+  [/Radeon\s+RX\s+6950\s+XT\b/i, 16 * 1024, 335],
+  [/Radeon\s+RX\s+6900\s+XT\b/i, 16 * 1024, 300],
+  [/Radeon\s+RX\s+6800\s+XT\b/i, 16 * 1024, 300],
+  [/Radeon\s+RX\s+6800\b/i, 16 * 1024, 250],
+  [/Radeon\s+RX\s+6750\s+XT\b/i, 12 * 1024, 250],
+  [/Radeon\s+RX\s+6700\s+XT\b/i, 12 * 1024, 230],
+  [/Radeon\s+RX\s+6600\s+XT\b/i, 8 * 1024, 160],
+  [/Radeon\s+RX\s+6600\b/i, 8 * 1024, 132],
+];
+
+function knownGpuSpec(gpu) {
+  for (const [re, vram_mb, gpu_power_w] of GPU_SPECS) {
+    if (re.test(gpu || "")) return { vram_mb, gpu_power_w };
+  }
+  return {};
+}
 
 function valid(s) {
   if (!s || typeof s !== "object") return false;
@@ -53,14 +81,15 @@ for (const file of files.sort()) {
     skipped++;
     continue;
   }
+  const fallbackSpec = knownGpuSpec(parsed.gpu);
   submissions.push({
     id: parsed.id ?? path.basename(file, ".json"),
     submitted_at: parsed.submitted_at ?? null,
     app_version: parsed.app_version ?? "",
     backend: parsed.backend,
     gpu: parsed.gpu ?? "",
-    vram_mb: typeof parsed.vram_mb === "number" ? parsed.vram_mb : null,
-    gpu_power_w: typeof parsed.gpu_power_w === "number" ? parsed.gpu_power_w : null,
+    vram_mb: typeof parsed.vram_mb === "number" ? parsed.vram_mb : (fallbackSpec.vram_mb ?? null),
+    gpu_power_w: typeof parsed.gpu_power_w === "number" ? parsed.gpu_power_w : (fallbackSpec.gpu_power_w ?? null),
     cpu: parsed.cpu ?? "",
     cpu_mhz: typeof parsed.cpu_mhz === "number" ? parsed.cpu_mhz : null,
     cpu_cores: typeof parsed.cpu_cores === "number" ? parsed.cpu_cores : null,

--- a/site/index.html
+++ b/site/index.html
@@ -206,9 +206,10 @@
           let html = "";
           for (const gpu of order) {
             const sys = groups[gpu].slice().sort((a, b) => best(b) - best(a));
+            const spec = sys.find((s) => vramText(s) || s.gpu_power_w) || sys[0];
             const tags = [`${sys.length} system${sys.length > 1 ? "s" : ""}`];
-            if (vramText(sys[0])) tags.push(vramText(sys[0]));
-            if (sys[0].gpu_power_w) tags.push(sys[0].gpu_power_w + "W");
+            if (vramText(spec)) tags.push(vramText(spec));
+            if (spec.gpu_power_w) tags.push(spec.gpu_power_w + "W");
             // Collapsed by default = a dense, scannable GPU directory. An active
             // search auto-opens its matches; "Expand all" opens everything.
             const open = (expandAll || f) ? " open" : "";


### PR DESCRIPTION
## Summary
- Write benchmark result cells with invariant-culture decimal dots so comma-decimal Windows locales do not drop decimal FPS values.
- Reject TensorRT benchmark submissions that identify a non-NVIDIA GPU, preventing AMD iGPU metadata from being accepted for NVIDIA TensorRT runs.
- Fill known AMD Radeon VRAM and board-power metadata in the generated benchmark catalog and preserve group metadata even when the fastest system lacks specs.

## Verification
- `node --check scripts/build-benchmarks.mjs`
- `node --check benchmark-proxy/src/index.js`
- `node scripts/build-benchmarks.mjs` confirmed AMD RX 7900 XTX and RX 9070 XT metadata is filled from the fallback table
- PowerShell formatting sanity check under `fr-FR` confirmed `604.8` stays dot-decimal