### PR TITLE
Benchmark: AMD Radeon RX 9070 XT (DirectML)

### DIFF
--- a/data/benchmarks/submissions/41d88cc4-3758-4a7d-a41a-2a6b74e158aa.json
+++ b/data/benchmarks/submissions/41d88cc4-3758-4a7d-a41a-2a6b74e158aa.json
@@ -1,0 +1,34 @@
+{
+  "schema": 1,
+  "id": "41d88cc4-3758-4a7d-a41a-2a6b74e158aa",
+  "submitted_at": "2026-06-17T20:43:42.466Z",
+  "app_version": "3.4.0",
+  "backend": "DirectML",
+  "gpu": "AMD Radeon RX 9070 XT",
+  "cpu": "AMD Ryzen 7 5800X3D 8-Core Processor",
+  "cpu_mhz": 3401,
+  "cpu_cores": 8,
+  "cpu_threads": 16,
+  "ram_mb": 32694,
+  "ram_speed_mhz": 3600,
+  "os": "Microsoft Windows 10.0.19045",
+  "driver": "32.0.31019.2002",
+  "results": {
+    "Balanced": {
+      "480x360": 606.2,
+      "640x480": 402.8,
+      "768x576": 301.2,
+      "1280x720": 118.4,
+      "1920x1080": 47.8
+    },
+    "Performance": {
+      "480x360": 601,
+      "640x480": 605.8,
+      "768x576": 601.2,
+      "1280x720": 245,
+      "1920x1080": 88.2
+    }
+  },
+  "submitted_by": "",
+  "note": ""
+}


### PR DESCRIPTION
Automated community benchmark submission.

- GPU: AMD Radeon RX 9070 XT
- Backend: DirectML
- App: 3.4.0
- OS: Microsoft Windows 10.0.19045
- Submitted by: (anonymous)

Merging publishes it to the catalog.