### PR TITLE
[codex] shorten packaged AnimeJaNai runtime paths

### DIFF
--- a/BuildMpvUpscale2xAnimeJaNai/mpv-upscale-2x_animejanai/portable_config/mpv-animejanai.conf
+++ b/BuildMpvUpscale2xAnimeJaNai/mpv-upscale-2x_animejanai/portable_config/mpv-animejanai.conf
@@ -115,4 +115,4 @@ loop-file=inf
 [upscale-off]
 vf=""
 [upscale-on]
-vf=@aji:animejanai:lib=~~/../animejanai/inference/aji.dll:conf=~~/../animejanai/animejanai.conf:model-dir=~~/../animejanai/onnx:rife-model-dir=~~/../animejanai/rife:trtexec=~~/../animejanai/inference/trtexec.exe:stats=~~/../animejanai/currentanimejanai.log:slot=1002
+vf=@aji:animejanai:lib=~~exe_dir/animejanai/inference/aji.dll:conf=~~exe_dir/animejanai/animejanai.conf:model-dir=~~exe_dir/animejanai/onnx:rife-model-dir=~~exe_dir/animejanai/rife:trtexec=~~exe_dir/animejanai/inference/trtexec.exe:stats=~~exe_dir/animejanai/currentanimejanai.log:slot=1002


### PR DESCRIPTION
## What changed
- Uses `~~exe_dir/animejanai/...` in the shipped mpv AnimeJaNai `vf` line instead of `~~/../animejanai/...`.
- This avoids handing the filter paths containing `portable_config/..`, which wastes path length in portable installs.

## Why
Deep portable installs can push TensorRT engine paths over Windows' legacy path limit. Shortening the configured model/inference paths lets already-generated 3.5.0 engines keep loading with their existing long filenames.

## Related native fixes
This package-side path shortening is one layer of the fix. Full protection for new builds is covered by:
- the-database/animejanai-inference#6: load legacy 3.5.0 engine names first, but build new engines using short cache filenames and long-path-safe file APIs.
- the-database/mpv#24: normalize expanded AnimeJaNai filter paths before passing them to `aji.dll`.

Once those ship as new release assets, this repo should bump `AjiVersion` and `MpvForkVersion` to consume them.

## Validation
- Ran `git diff --check`.
- Verified the reported portable path math: old runtime path with `portable_config/..` was about 271 chars; exe-dir normalized legacy engine path is about 252 chars.
- Could not run `dotnet build` in this Codex environment because no .NET SDK is installed.