### PR TITLE
deps: TensorRT 11.1, aji v0.8.0, mpv fork 2026-07-23, 7-Zip 26.02

### DIFF
--- a/BuildMpvUpscale2xAnimeJaNai/Program.cs
+++ b/BuildMpvUpscale2xAnimeJaNai/Program.cs
@@ -25,13 +25,13 @@ using static Downloader;
 // The inference runtime (TensorRT + trtexec) is reused from the vs-mlrt cuda
 // release archives on Windows; publicly downloadable, license-precedented, and
 // trtexec is version-matched to nvinfer by construction. aji_trt must be built
-// against the SAME TensorRT major.minor (v16.x == TensorRT 11.0).
-// NOTE: v16.test1 is vs-mlrt's TRT 11 PRE-release - recheck for a stable
+// against the SAME TensorRT major.minor (v16.1.x == TensorRT 11.1 / CUDA 13.3).
+// NOTE: v16.1.test1 is vs-mlrt's TRT 11.1 PRE-release - recheck for a stable
 // v16 tag before cutting the package release.
-const string VsMlrtCudaVersion    = "v16.test1";
-const string AjiVersion           = "v0.7.0";       // github.com/the-database/animejanai-inference release tag (DML 4:4:4 input; op21 SD preset; missing-model passthrough; configurable RIFE/upscale order; benchmark slots 1012/1013)
+const string VsMlrtCudaVersion    = "v16.1.test1";
+const string AjiVersion           = "v0.8.0";       // github.com/the-database/animejanai-inference release tag (built against TensorRT 11.1; engine cache path handling fix for long / non-ASCII install paths)
 
-const string SevenZipVersion      = "2501";         // 7-zip "extra" (Windows) / linux-x64 standalone console version
+const string SevenZipVersion      = "2602";         // 7-zip "extra" (Windows) / linux-x64 standalone console version
 const string MpvNetVersion        = "v7.1.2.0";
 const string ManagerVersion       = "0.4.0";        // github.com/the-database/AnimeJaNaiManager release tag (AnimeJaNai Manager)
 
@@ -52,12 +52,12 @@ const string RifeModelsVersion    = "models-rife-fp16-1"; // animejanai-inferenc
 // IMPORTANT: the filter now lives on the mpv fork's `master` branch (aji ABI
 // v8); the old standalone `vf-animejanai` branch is stale (ABI v4) and must
 // NOT be used. The pin below is a master commit.
-const string MpvForkVersion       = "2026-06-20-b903de7812"; // release tag (Windows winbuild)
-const string MpvForkBuildDate     = "20260620";     // build date in the Windows dev archive filename
-const string MpvForkGitHash       = "b903de7812";   // git short hash (master; aji ABI v8)
+const string MpvForkVersion       = "2026-07-23-7fc08d90c7"; // release tag (Windows winbuild)
+const string MpvForkBuildDate     = "20260723";     // build date in the Windows dev archive filename
+const string MpvForkGitHash       = "7fc08d90c7";   // git short hash (master; aji ABI v8)
 // Linux mpv bundle: a github.com/the-database/mpv release asset (tar.zst).
 // Overridable via MPV_LINUX_LOCAL (a local meson build dir, e.g. ~/src/mpv/build).
-const string MpvForkLinuxVersion  = "2026-06-20-b903de7";
+const string MpvForkLinuxVersion  = "2026-07-23-7fc08d9";
 
 // ---------------------------------------------------------------------------
 // Target / platform descriptor
@@ -220,7 +220,7 @@ async Task InstallInferenceRuntime()
         var trtLib = Path.Combine(trtRoot, "lib", "x86_64-linux-gnu");
         var trtBin = Path.Combine(trtRoot, "bin");
         var cudaLib = Environment.GetEnvironmentVariable("CUDA_LINUX_LIB")
-                      ?? "/usr/local/cuda-13.2/lib64";
+                      ?? "/usr/local/cuda-13.3/lib64";
         Console.WriteLine($"Copying TensorRT runtime from {trtLib} + cudart from {cudaLib}...");
 
         // Versioned runtime libraries (and the unversioned/.11 symlinks) the

--- a/build/Dockerfile.ubuntu2204
+++ b/build/Dockerfile.ubuntu2204
@@ -5,7 +5,7 @@
 # mainstream distro from ~2022 on (the NVIDIA libs we bundle need just
 # glibc 2.17-2.27, so they are never the constraint).
 #
-# This image carries the *toolchain + apt-able deps + CUDA 13.2 + TensorRT 11*.
+# This image carries the *toolchain + apt-able deps + CUDA 13.3 + TensorRT 11*.
 # The modern stack that 22.04 ships too old (wayland, FFmpeg, libplacebo, mpv,
 # aji) is built from source by build-stack.sh, run inside a container from this
 # image with the repos mounted, so that step stays iterable without image rebuilds.
@@ -49,34 +49,36 @@ ENV DOTNET_ROOT=/usr/lib/dotnet
 ENV PATH="/usr/lib/dotnet:${PATH}"
 
 # 7-Zip console (7zz) used by the assembler/packaging.
-RUN curl -fsSL https://www.7-zip.org/a/7z2501-linux-x64.tar.xz -o /tmp/7z.tar.xz \
+RUN curl -fsSL https://www.7-zip.org/a/7z2602-linux-x64.tar.xz -o /tmp/7z.tar.xz \
     && mkdir -p /tmp/7z && tar -xf /tmp/7z.tar.xz -C /tmp/7z \
     && install -m755 /tmp/7z/7zz /usr/local/bin/7zz && rm -rf /tmp/7z /tmp/7z.tar.xz
 
-# CUDA 13.2 toolkit + TensorRT 11.0.0 from NVIDIA's apt repo (ubuntu2204).
-# TRT 11.0.0 members are pinned explicitly (the metapackage drags in Windows /
+# CUDA 13.3 toolkit + TensorRT 11.1.0 from NVIDIA's apt repo (ubuntu2204).
+# Matches the TensorRT the Windows package ships (vs-mlrt v16.1.x = TRT 11.1 /
+# CUDA 13.3), so aji_trt is built against the same major.minor it runs on.
+# TRT 11.1.0 members are pinned explicitly (the metapackage drags in Windows /
 # python bits, and minor-version resolution differs across apt versions).
 RUN curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb -o /tmp/cuda-keyring.deb \
     && dpkg -i /tmp/cuda-keyring.deb && rm /tmp/cuda-keyring.deb \
     && apt-get update && apt-get install -y --no-install-recommends \
-        cuda-nvcc-13-2 cuda-cudart-dev-13-2 cuda-nvrtc-13-2 \
-        cuda-driver-dev-13-2 \
-        libnvinfer11=11.0.0.114-1+cuda13.2 \
-        libnvinfer-plugin11=11.0.0.114-1+cuda13.2 \
-        libnvinfer-vc-plugin11=11.0.0.114-1+cuda13.2 \
-        libnvinfer-lean11=11.0.0.114-1+cuda13.2 \
-        libnvinfer-dispatch11=11.0.0.114-1+cuda13.2 \
-        libnvonnxparsers11=11.0.0.114-1+cuda13.2 \
-        libnvinfer-headers-dev=11.0.0.114-1+cuda13.2 \
-        libnvinfer-safe-headers-dev=11.0.0.114-1+cuda13.2 \
-        libnvinfer-headers-plugin-dev=11.0.0.114-1+cuda13.2 \
-        libnvinfer-dev=11.0.0.114-1+cuda13.2 \
-        libnvinfer-plugin-dev=11.0.0.114-1+cuda13.2 \
-        libnvonnxparsers-dev=11.0.0.114-1+cuda13.2 \
-        libnvinfer-bin=11.0.0.114-1+cuda13.2 \
+        cuda-nvcc-13-3 cuda-cudart-dev-13-3 cuda-nvrtc-13-3 \
+        cuda-driver-dev-13-3 \
+        libnvinfer11=11.1.0.106-1+cuda13.3 \
+        libnvinfer-plugin11=11.1.0.106-1+cuda13.3 \
+        libnvinfer-vc-plugin11=11.1.0.106-1+cuda13.3 \
+        libnvinfer-lean11=11.1.0.106-1+cuda13.3 \
+        libnvinfer-dispatch11=11.1.0.106-1+cuda13.3 \
+        libnvonnxparsers11=11.1.0.106-1+cuda13.3 \
+        libnvinfer-headers-dev=11.1.0.106-1+cuda13.3 \
+        libnvinfer-safe-headers-dev=11.1.0.106-1+cuda13.3 \
+        libnvinfer-headers-plugin-dev=11.1.0.106-1+cuda13.3 \
+        libnvinfer-dev=11.1.0.106-1+cuda13.3 \
+        libnvinfer-plugin-dev=11.1.0.106-1+cuda13.3 \
+        libnvonnxparsers-dev=11.1.0.106-1+cuda13.3 \
+        libnvinfer-bin=11.1.0.106-1+cuda13.3 \
     && rm -rf /var/lib/apt/lists/*
-ENV PATH="/usr/local/cuda-13.2/bin:${PATH}"
-ENV CUDACXX=/usr/local/cuda-13.2/bin/nvcc
+ENV PATH="/usr/local/cuda-13.3/bin:${PATH}"
+ENV CUDACXX=/usr/local/cuda-13.3/bin/nvcc
 
 # Where build-stack.sh installs the from-source stack (kept off /usr so it is
 # easy to collect for bundling).


### PR DESCRIPTION
Dependency bumps in the assembler:

| pin | old | new |
| --- | --- | --- |
| `VsMlrtCudaVersion` | `v16.test1` (TRT 11.0 / CUDA 13.2) | `v16.1.test1` (TRT 11.1.0.106 / CUDA 13.3) |
| `AjiVersion` | `v0.7.0` | `v0.8.0` (built against TRT 11.1) |
| `MpvForkVersion` / date / hash | `2026-06-20-b903de7812` | `2026-07-23-7fc08d90c7` |
| `MpvForkLinuxVersion` | `2026-06-20-b903de7` | `2026-07-23-7fc08d9` |
| `SevenZipVersion` | `2501` | `2602` |

Already current, unchanged: mpv.net v7.1.2.0, Manager 0.4.0, ONNX Runtime DirectML 1.24.4, DirectML 1.15.4, RIFE model set.

The mpv fork bump carries the sw-decode format fix (the-database/mpv#55), `vf_animejanai: drain backend on reset`, and filter path normalization; `AJI_API_VERSION` is 8 on both sides, unchanged.

Engine caches are keyed by TensorRT version (`.trt-<ver>.gpu-<name>.engine`), so 11.0 engines are removed and rebuilt on first play — verified on a 11.1 harness run.

The Linux build image tracks the same TensorRT 11.1 / CUDA 13.3 from NVIDIA's apt repo, and `CUDA_LINUX_LIB` defaults to the 13.3 toolkit lib.