### PR TITLE
subtitles: opt-in GPU subtitle rendering preset

### DIFF
--- a/BuildMpvUpscale2xAnimeJaNai/Program.cs
+++ b/BuildMpvUpscale2xAnimeJaNai/Program.cs
@@ -33,7 +33,7 @@ const string AjiVersion           = "v0.8.0";       // github.com/the-database/a
 
 const string SevenZipVersion      = "2602";         // 7-zip "extra" (Windows) / linux-x64 standalone console version
 const string MpvNetVersion        = "v7.1.2.0";
-const string ManagerVersion       = "0.4.0";        // github.com/the-database/AnimeJaNaiManager release tag (AnimeJaNai Manager)
+const string ManagerVersion       = "0.5.0";        // github.com/the-database/AnimeJaNaiManager release tag (AnimeJaNai Manager; adds the GPU subtitle rendering toggle)
 
 // DirectML backend runtime (backend=DirectML in animejanai.conf). These are
 // the last DirectML-flavored releases: Microsoft moved DML to sustained

--- a/BuildMpvUpscale2xAnimeJaNai/mpv-upscale-2x_animejanai/portable_config/mpv-animejanai.conf
+++ b/BuildMpvUpscale2xAnimeJaNai/mpv-upscale-2x_animejanai/portable_config/mpv-animejanai.conf
@@ -73,6 +73,21 @@ volume-max=100
 # blend-subtitles=no in mpv.conf.
 blend-subtitles=video
 
+# The stable subtitle path: every GPU/threaded subtitle feature of the mpv fork
+# is off, so rendering behaves like stock mpv. The AnimeJaNai Manager's "GPU
+# Subtitle Rendering (Experimental)" checkbox switches this for the [subs-gpu]
+# profile below. Set any of these in mpv.conf to override (mpv.conf applies
+# this profile first, so your own lines win).
+sub-gpu-raster=no
+sub-render-ahead-frames=0
+# 1 = single-threaded libass (0 would mean "auto", i.e. one thread per CPU).
+sub-ass-render-threads=1
+# 0 = no overlay-build deadline (-1 would arm it at the frame duration, which
+# can substitute a stale or empty overlay when a frame's subtitles run long).
+sub-present-guard-ms=0
+osd-render-res-cap=0
+# stats.lua's persistent_overlay defaults to no, so nothing to set here.
+
 alang = 'jpn'
 slang = 'eng'
 
@@ -106,6 +121,33 @@ loop-file=inf
 # loop .webm animations
 [extension.webm]
 loop-file=inf
+
+# Experimental GPU subtitle rendering. Opt-in: enabled by the AnimeJaNai
+# Manager's "GPU Subtitle Rendering" checkbox, which writes
+# [global] sub_render_mode=gpu into animejanai.conf; scripts/
+# animejanai_backend.lua applies this profile at startup when it sees that.
+# Applying it by hand (profile=subs-gpu in mpv.conf) works too.
+#
+# ASS/SSA glyph rasterization, blur and compositing run on the GPU
+# (sub-gpu-raster), subtitles for upcoming frames are rendered on a worker
+# thread instead of the display thread (sub-render-ahead-frames), and the
+# overlay build gets a per-frame deadline so a heavy subtitle frame can never
+# stall presentation (sub-present-guard-ms=-1 = the frame duration). The OSD
+# (stats display, OSC) is rendered at up to 1440p and GPU-upscaled so it does
+# not contend with subtitles at 4K+. Requires vo=gpu-next and the forked
+# libass; both ship with this package. Subtitles must be composited as an
+# overlay rather than blended into the video frame, hence blend-subtitles=no.
+[subs-gpu]
+blend-subtitles=no
+sub-gpu-raster=yes
+sub-render-ahead-frames=24
+# 0 = auto: one libass render thread per CPU.
+sub-ass-render-threads=0
+sub-present-guard-ms=-1
+osd-render-res-cap=1440
+# The stats overlay (Ctrl+J) redraws constantly; keeping it in its own OSD
+# layer stops it from being overwritten by - and fighting with - other OSD output.
+script-opts-append=stats-persistent_overlay=yes
 
 # Native inference filter (vf_animejanai): a single profile inserts the
 # filter; slots switch at runtime via vf-command (see input.conf) without

--- a/BuildMpvUpscale2xAnimeJaNai/mpv-upscale-2x_animejanai/portable_config/scripts/animejanai_backend.lua
+++ b/BuildMpvUpscale2xAnimeJaNai/mpv-upscale-2x_animejanai/portable_config/scripts/animejanai_backend.lua
@@ -14,6 +14,12 @@
 -- gpu-api=vulkan,auto); this script overrides both for DirectML. Runs
 -- at startup, before the first file loads, so the first play already
 -- decodes and renders on the right path.
+--
+-- Also applies the opt-in subtitle rendering mode: the Manager writes
+-- [global] sub_render_mode=gpu into animejanai.conf, and this script applies
+-- the [subs-gpu] profile from mpv-animejanai.conf. The settings live in that
+-- profile (not here) so they can change with the player build without
+-- touching this script or the Manager.
 
 local mp = require 'mp'
 local msg = require 'mp.msg'
@@ -29,6 +35,7 @@ local function read_conf()
     end
     local backend
     local default_slot
+    local sub_render_mode
     local rife = false
     local in_global = false
     for line in f:lines() do
@@ -44,13 +51,17 @@ local function read_conf()
             if d then
                 default_slot = tonumber(d)
             end
+            local s = line:match('^sub_render_mode=([^%s]+)')
+            if s then
+                sub_render_mode = s
+            end
         end
         if line:match('^chain_%d+_rife=yes') or line:match('^chain_%d+_rife=true') then
             rife = true
         end
     end
     f:close()
-    return backend, rife, default_slot
+    return backend, rife, default_slot, sub_render_mode
 end
 
 local function exists(rel)
@@ -145,7 +156,7 @@ local function check_components(backend, rife_configured)
     end)
 end
 
-local backend_raw, rife_configured, default_slot = read_conf()
+local backend_raw, rife_configured, default_slot, sub_render_mode = read_conf()
 local backend = (backend_raw or 'TensorRT'):lower()
 local hwdec = 'nvdec'
 -- DirectML/ncnn use D3D11 frames (hwdec=d3d11va, gpu-api=d3d11). Windows-only:
@@ -159,6 +170,15 @@ end
 mp.set_property('hwdec', hwdec)
 msg.info(string.format('backend %s -> hwdec=%s%s', backend, hwdec,
                        hwdec == 'd3d11va' and ', gpu-api=d3d11' or ''))
+
+-- Opt-in GPU subtitle rendering: only ever applied on top of the stable
+-- defaults, never the reverse, so a user who set any of these options in
+-- mpv.conf keeps them as long as the mode is off. Applied here rather than in
+-- mpv.conf so the Manager stays the single writer of animejanai.conf.
+if (sub_render_mode or ''):lower() == 'gpu' then
+    mp.commandv('apply-profile', 'subs-gpu')
+    msg.info('sub_render_mode gpu -> applied profile subs-gpu')
+end
 
 -- The Manager's "Set as Default Profile" stores the chosen slot here. mpv
 -- rebuilds the filter chain from the vf string (which bakes in Balanced, 1002)

--- a/BuildMpvUpscale2xAnimeJaNai/mpv-upscale-2x_animejanai/portable_config/scripts/animejanai_backend.lua
+++ b/BuildMpvUpscale2xAnimeJaNai/mpv-upscale-2x_animejanai/portable_config/scripts/animejanai_backend.lua
@@ -175,9 +175,74 @@ msg.info(string.format('backend %s -> hwdec=%s%s', backend, hwdec,
 -- defaults, never the reverse, so a user who set any of these options in
 -- mpv.conf keeps them as long as the mode is off. Applied here rather than in
 -- mpv.conf so the Manager stays the single writer of animejanai.conf.
-if (sub_render_mode or ''):lower() == 'gpu' then
-    mp.commandv('apply-profile', 'subs-gpu')
+--
+-- A plain `apply-profile subs-gpu` would break mpv.conf's contract that your
+-- own lines win: the config is fully parsed before scripts run, so the profile
+-- would overwrite settings you made by hand. Instead each option is applied
+-- only while it still holds the managed default from [animejanai] (or, for an
+-- option that profile does not set, mpv's own default) - a different value can
+-- only have come from your mpv.conf, so it is left alone. Both value sets are
+-- read from profile-list, keeping the option lists in mpv-animejanai.conf.
+--
+-- Ambiguity worth knowing about: setting an option in mpv.conf to exactly the
+-- managed default is indistinguishable from not setting it at all (mpv does
+-- not record where a value came from), so that one does get the preset value.
+local function profile_options(list, name)
+    for _, p in ipairs(list) do
+        if p.name == name then
+            return p.options or {}
+        end
+    end
+    return nil
+end
+
+local function apply_subs_gpu()
+    local profiles = mp.get_property_native('profile-list') or {}
+    local preset = profile_options(profiles, 'subs-gpu')
+    if not preset then
+        msg.warn('sub_render_mode=gpu but no subs-gpu profile - ' ..
+                 'is mpv-animejanai.conf up to date?')
+        return
+    end
+    local managed = profile_options(profiles, 'animejanai') or {}
+
+    local function managed_value(key)
+        for _, o in ipairs(managed) do
+            if o.key == key then
+                return o.value
+            end
+        end
+        return mp.get_property('option-info/' .. key .. '/default-value')
+    end
+
+    local function norm(v)
+        return (tostring(v or ''):match('^%s*(.-)%s*$')):lower()
+    end
+
+    for _, o in ipairs(preset) do
+        if o.key == 'script-opts-append' then
+            -- One "key=value" script option. It shares the script-opts map with
+            -- everything else, so append it only when that key is unset.
+            local k, v = tostring(o.value):match('^([^=]+)=(.*)$')
+            local opts = mp.get_property_native('script-opts') or {}
+            if k and opts[k] == nil then
+                opts[k] = v
+                mp.set_property_native('script-opts', opts)
+            elseif k then
+                msg.info('subs-gpu: keeping your script-opt ' .. k .. '=' .. tostring(opts[k]))
+            end
+        elseif norm(mp.get_property(o.key)) == norm(managed_value(o.key)) then
+            mp.set_property(o.key, o.value)
+        else
+            msg.info(string.format('subs-gpu: keeping your %s=%s', o.key,
+                                   tostring(mp.get_property(o.key))))
+        end
+    end
     msg.info('sub_render_mode gpu -> applied profile subs-gpu')
+end
+
+if (sub_render_mode or ''):lower() == 'gpu' then
+    apply_subs_gpu()
 end
 
 -- The Manager's "Set as Default Profile" stores the chosen slot here. mpv

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,11 @@ filter calling the `aji` engine. The chain when a user plays a video:
    worker, OSD render cap, persistent stats overlay). The Manager's "GPU Subtitle Rendering"
    checkbox writes `[global] sub_render_mode=gpu`, and `scripts/animejanai_backend.lua` applies
    the profile at startup. Keep the option list in the profile, not in the Lua or the Manager.
+   The script applies each option **only while it still holds the managed default** (read from
+   `profile-list`, falling back to `option-info/<key>/default-value`) — scripts run after the
+   config is parsed, so a blanket `apply-profile` would override the user's own `mpv.conf` lines
+   and break the "your settings win" contract that `mpv.conf` and `mpv-animejanai.conf` promise.
+   Any future script-applied preset must follow the same rule.
 
 ### Config (`animejanai.conf`)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,6 +134,13 @@ filter calling the `aji` engine. The chain when a user plays a video:
    backend on startup. (`ncnn` is retired and treated as DirectML by the shim.)
 7. **RIFE** interpolation runs after upscaling by default, or before it when a chain sets
    `rife_before_upscale`; RIFE model files live in `animejanai/rife/` (downloaded by `InstallRife()`).
+8. **Subtitle rendering** has two managed presets in `portable_config/mpv-animejanai.conf`: the
+   stable defaults inside `[animejanai]` (every GPU/threaded subtitle feature of the fork off —
+   note `sub-ass-render-threads=1` and `sub-present-guard-ms=0` are the *off* values; `0` and `-1`
+   mean auto/armed) and the opt-in `[subs-gpu]` profile (GPU glyph raster + blur, render-ahead
+   worker, OSD render cap, persistent stats overlay). The Manager's "GPU Subtitle Rendering"
+   checkbox writes `[global] sub_render_mode=gpu`, and `scripts/animejanai_backend.lua` applies
+   the profile at startup. Keep the option list in the profile, not in the Lua or the Manager.
 
 ### Config (`animejanai.conf`)
 
@@ -146,6 +153,10 @@ The `aji` engine parses `animejanai.conf` (the old Python `animejanai_config.rea
 - **User slots `1`–`9`** are parsed from `animejanai.conf` (`[slot_N]`,
   `chain_<n>_model_<m>_<field>` keys, `[global]` settings like `backend=`). The AnimeJaNai Manager
   writes this file.
+- **Player-only `[global]` keys.** `default_slot` and `sub_render_mode` are written by the Manager
+  and read by the Lua scripts, not by the engine (`aji_conf.cpp` looks up only the keys it knows, so
+  unknown ones are ignored). This is the pattern for any future "Manager configures mpv" setting:
+  a `[global]` key here, the actual mpv options in a managed profile.
 
 ### Stats overlay
 


### PR DESCRIPTION
Adds a managed `[subs-gpu]` mpv profile plus the plumbing for the AnimeJaNai Manager to toggle it (Manager side: the-database/AnimeJaNaiManager#6).

**How it is wired.** The Manager writes `[global] sub_render_mode=gpu` into `animejanai.conf` — the file it already owns — and `portable_config/scripts/animejanai_backend.lua` applies `apply-profile subs-gpu` at startup, next to where it already aligns `hwdec`/`gpu-api` to the backend. `mpv.conf` is never written, so a user's own lines are untouched and the AppImage's read-only tree is a non-issue. The option list lives in the profile, so it can follow the player build without a Manager release.

**Stable defaults are now explicit** in `[animejanai]`. Two of them are deliberately *not* the option defaults:

| option | shipped default | why |
| --- | --- | --- |
| `sub-ass-render-threads` | `1` | `0` means auto — one libass render thread per CPU (`sub/sd_ass.c`), i.e. the fork's parallel path stays on |
| `sub-present-guard-ms` | `0` | `-1` arms the overlay-build deadline at the frame duration; its checkpoints are in the generic `update_overlays()` (`vo_gpu_next.c:5480`, `:5507`), so a slow CPU libass frame can be served as a stale/empty overlay even with `sub-gpu-raster=no` |

`blend-subtitles=video`, `sub-gpu-raster=no`, `sub-render-ahead-frames=0`, `osd-render-res-cap=0` match the option defaults; `stats-persistent_overlay` is left unset because stats.lua already defaults it to `no` (avoids a duplicate key in the `script-opts` list).

**Depends on #161** — four of these options only exist in the mpv fork build pinned there (`2026-07-23-7fc08d90c7`); on the previous pin mpv would fail to parse the managed conf. Based on that branch; retarget to `main` once it merges.

**Verified** against the pinned player build (`mpv-x86_64-20260723-git-7fc08d90c7`) with a throwaway config tree, reading the properties back at runtime:

- no key → `blend-subtitles=video`, `sub-gpu-raster=no`, `sub-render-ahead-frames=0`, `sub-ass-render-threads=1`, `sub-present-guard-ms=0`, `osd-render-res-cap=0`, `stats-persistent_overlay=nil`
- `sub_render_mode=gpu` → `no` / `yes` / `24` / `0` / `-1` / `1440` / `yes`

No option-parse errors in either case, and `script-opts-append` works from a runtime-applied profile.