### PR TITLE
builder: also ship the standalone mpv.exe from the fork build

### DIFF
--- a/BuildMpvUpscale2xAnimeJaNai/Program.cs
+++ b/BuildMpvUpscale2xAnimeJaNai/Program.cs
@@ -418,6 +418,41 @@ async Task InstallCustomLibmpv()
     File.Delete(targetPath);
 }
 
+// Windows standalone player: mpv.exe from the SAME fork build as the libmpv
+// above (mpv-winbuild's player archive vs. its dev archive). This mpv.exe is
+// fully self-contained - statically linked, no libmpv-2.dll dependency - and
+// carries the vf_animejanai filter, so users who prefer plain mpv.exe over
+// mpv.net can launch it directly. Placed next to portable_config/ at the
+// install root, it auto-detects that config dir and runs the same managed
+// profiles/scripts/upscaling as mpvnet.exe. Shipped alongside mpv.net, not
+// instead of it (mpvnet.exe stays the default launcher in manifest.json).
+async Task InstallCustomMpvExe()
+{
+    Console.WriteLine("Downloading custom mpv.exe fork...");
+    var downloadUrl = $"https://github.com/the-database/mpv-winbuild/releases/download/{MpvForkVersion}/mpv-x86_64-{MpvForkBuildDate}-git-{MpvForkGitHash}.7z";
+    var targetPath = Path.GetFullPath("mpv-player.7z");
+    await Downloader.DownloadFileAsync(downloadUrl, targetPath, (progress) =>
+    {
+        Console.WriteLine($"Downloading custom mpv.exe fork ({progress}%)...");
+    });
+
+    Console.WriteLine("Extracting custom mpv.exe fork...");
+    // Just the player entry points: mpv.exe (GUI) + mpv.com (console wrapper).
+    // Skip the archive's docs, updater.bat and file-association scripts.
+    var want = new[] { "mpv.exe", "mpv.com" };
+    using (ArchiveFile archiveFile = new(targetPath))
+    {
+        foreach (var entry in archiveFile.Entries)
+        {
+            if (want.Contains(entry.FileName, StringComparer.OrdinalIgnoreCase))
+            {
+                entry.Extract(Path.Combine(installDirectory, entry.FileName));
+            }
+        }
+    }
+    File.Delete(targetPath);
+}
+
 // Linux player: the mpv fork bundle (mpv + libmpv.so.2 carrying vf_animejanai,
 // plus the .so deps mpv needs). From a github.com/the-database/mpv release
 // (tar.zst) or a local meson build dir via MPV_LINUX_LOCAL. The portable_config
@@ -837,6 +872,7 @@ async Task Main()
     {
         await InstallMpvnet();
         await InstallCustomLibmpv();
+        await InstallCustomMpvExe();
     }
     else
     {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,10 @@ It contains:
 
 1. **`BuildMpvUpscale2xAnimeJaNai/`** — a C# console app (`Program.cs`, top-level statements) whose
    only job is to download the pieces and assemble them: mpv.net, a custom **libmpv fork** (carries
-   the `vf_animejanai` filter), the **`aji` native inference shim** (`aji.dll` + `aji_trt.dll` /
+   the `vf_animejanai` filter; from mpv-winbuild's *dev* archive) plus the matching **standalone
+   `mpv.exe`** (from the same release's *player* archive — a self-contained static build with the
+   filter compiled in, shipped next to `mpvnet.exe` for users who prefer plain mpv; it auto-detects
+   the same `portable_config/`), the **`aji` native inference shim** (`aji.dll` + `aji_trt.dll` /
    `aji_dml.dll`), the **TensorRT runtime + `trtexec`** (lifted from the vs-mlrt cuda archive),
    **ONNX Runtime DirectML + `DirectML.dll`**, RIFE models, `yt-dlp`, the AnimeJaNai Manager, and
    the AnimeJaNaiUpdater — then layers the runtime files in


### PR DESCRIPTION
The builder pulled only `libmpv-2.dll` (for mpv.net) from the mpv-winbuild **dev** archive. This also fetches `mpv.exe` + `mpv.com` from the same release's **player** archive and drops them at the install root, so users who prefer plain mpv over mpv.net can launch it directly — same request, same upscaling.

**Why it just works as a drop-in:**
- That `mpv.exe` is a self-contained static build — `dumpbin /dependents` shows only Windows system DLLs + `vulkan-1.dll`, **no** `libmpv-2.dll` dependency — so it's independent of the shared libmpv the mpv.net path uses.
- `vf_animejanai` is compiled in (`--vf=help` lists `animejanai   AnimeJaNai AI upscaling filter (CUDA/D3D11)`), same git hash as the pinned fork (`g7fc08d90c`).
- Placed next to `portable_config/`, it auto-detects it — verified by launching with no `--config-dir` and seeing `animejanai_backend.lua` run and apply the profile. So it gets the same managed config, scripts, keybindings, and upscaling as `mpvnet.exe`.

`mpvnet.exe` stays the default launcher (`player_launcher` in manifest.json is unchanged); this is an alternative shipped alongside it.

**Packaging:** heavy (118 MB) and fork-versioned like `libmpv-2.dll`, so it stays out of `overlay_paths` and rides full updates (governed by the `mpvfork` dep — an overlay update only happens when `mpvfork` is unchanged, i.e. when `mpv.exe` is unchanged too). Windows-only; the Linux target already installs the mpv binary in `InstallLinuxMpv`.

**Verified:** the extraction loop selects exactly `mpv.exe` + `mpv.com` from the archive (nested entries like `doc\manual.pdf` don't match the exact names); the extracted binary is byte-identical (SHA-256) to a `7z.exe` extraction and runs. Assembler builds clean.