### PR TITLE
updater: verify component content instead of trusting components.json

### DIFF
--- a/AnimeJaNaiUpdater/Program.cs
+++ b/AnimeJaNaiUpdater/Program.cs
@@ -892,11 +892,45 @@ async Task<PackIndex> GetPackIndexAsync()
             assets.FirstOrDefault(a => a.Name == asset)?.Url,
             e.GetProperty("bytes").GetInt64(),
             files,
-            e.TryGetProperty("dep", out var d) ? d.GetString() : null));
+            e.TryGetProperty("dep", out var d) ? d.GetString() : null,
+            e.TryGetProperty("installed_bytes", out var ib) ? ib.GetInt64() : 0));
     }
     return new PackIndex(
         doc.RootElement.TryGetProperty("package_version", out var v)
             ? v.GetString() ?? "" : "", packs);
+}
+
+// Does the pack's content on disk actually match the published pack? components.json records only
+// what the updater BELIEVES it installed, and that record can be wrong - e.g. a component whose
+// download was skipped or failed while the record was still written, leaving the previous release's
+// files in place. That state is self-perpetuating: the record then says "current" forever and the
+// real files are never refreshed (this is how a TensorRT 11.0 runtime survived an upgrade to a
+// package built for 11.1). Comparing the total extracted size against the index catches it - a
+// different upstream build is a different size - and costs only a directory stat.
+// Older indexes carry no installed_bytes; there is nothing to verify against, so trust the record.
+bool PackContentMatches(Pack pack)
+{
+    if (pack.InstalledBytes <= 0)
+    {
+        return true;
+    }
+    long actual = 0;
+    foreach (var f in pack.Files)
+    {
+        var fi = new FileInfo(Path.Combine(installDir, f));
+        if (!fi.Exists)
+        {
+            return false;
+        }
+        actual += fi.Length;
+    }
+    if (actual != pack.InstalledBytes)
+    {
+        Console.WriteLine($"{pack.Name}: on-disk content does not match the published pack " +
+                          $"({actual:N0} vs {pack.InstalledBytes:N0} bytes); reinstalling.");
+        return false;
+    }
+    return true;
 }
 
 // Installed state: components.json, else inferred from what's on disk so
@@ -1082,7 +1116,7 @@ async Task<int> InstallComponentAsync(string name)
     string target = pack.Dep is null ? "" : ReadManifestDep(localManifest, pack.Dep);
     bool filesPresent = pack.Files.Count > 0 &&
         pack.Files.All(f => File.Exists(Path.Combine(installDir, f)));
-    if (filesPresent && target != "")
+    if (filesPresent && target != "" && PackContentMatches(pack))
     {
         string prev = pack.Dep is null ? "" :
             ReadManifestDep(Path.Combine(installDir, "manifest.prev.json"), pack.Dep);
@@ -1153,8 +1187,16 @@ async Task<int> AutoComponentsAsync()
     var (hasNvidia, sm, gpu) = DetectGpu();
     var rec = RecommendedPacks(index, hasNvidia, sm);
     var installed = ReadInstalledComponents(index);
+    // "Needs installing" is not just "absent": a pack already recorded as installed is stale when
+    // the dep that governs it moved (a TensorRT/RIFE bump) or when its files on disk are not this
+    // pack's content. Without this, --auto reports "everything is installed" after an upgrade and
+    // the old runtime is kept forever; InstallComponentAsync re-checks and still skips genuine no-ops.
     var missing = index.Packs
-        .Where(p => PreselectPack(p, installed, rec) && !installed.ContainsKey(p.Name))
+        .Where(p => PreselectPack(p, installed, rec))
+        .Where(p => !installed.TryGetValue(p.Name, out var recorded) ||
+                    (p.Dep is not null && ReadManifestDep(localManifest, p.Dep) is string t &&
+                     t != "" && recorded != t) ||
+                    !PackContentMatches(p))
         .Select(p => p.Name).ToList();
     if (missing.Count == 0)
     {
@@ -1229,5 +1271,9 @@ static class Nvml
 
 record Release(string Tag, List<Asset> Assets);
 record Asset(string Name, string Url);
-record Pack(string Name, string Asset, string? Url, long Bytes, List<string> Files, string? Dep);
+// InstalledBytes: the pack's total size once extracted (sum of its files on disk). Used to verify
+// that what is on disk really is this pack's content, since components.json bookkeeping alone can
+// be wrong. 0 when the index predates the field (older release) - verification is then skipped.
+record Pack(string Name, string Asset, string? Url, long Bytes, List<string> Files, string? Dep,
+            long InstalledBytes = 0);
 record PackIndex(string PackageVersion, List<Pack> Packs);

--- a/BuildMpvUpscale2xAnimeJaNai/Program.cs
+++ b/BuildMpvUpscale2xAnimeJaNai/Program.cs
@@ -1019,12 +1019,23 @@ async Task<List<string>> EmitComponentPacks()
                     .Select(x => Path.GetRelativePath(installDirectory, x))
                 : new[] { f };
         }).Select(f => f.Replace('\\', '/')).ToArray();
+        // installed_bytes: what this pack occupies once extracted. The updater compares it against
+        // the files actually on disk to decide whether an install is genuinely current, instead of
+        // trusting components.json alone - a record can claim a component is up to date while the
+        // previous release's files are still there (that is how a TensorRT 11.0 runtime survived an
+        // upgrade to a package built for 11.1). Measured before SlimInstallTree removes them.
+        long installedBytes = allFiles.Sum(f =>
+        {
+            var fi = new FileInfo(Path.Combine(installDirectory, f));
+            return fi.Exists ? fi.Length : 0L;
+        });
         index.Add(new
         {
             name,
             dep,
             asset = Path.GetFileName(archive),
             bytes = new FileInfo(archive).Length,
+            installed_bytes = installedBytes,
             files = allFiles,
         });
         packedFiles.AddRange(allFiles);


### PR DESCRIPTION
Upgrading to a release with a new TensorRT could silently keep the **old** runtime.

`components.json` records what the updater *believes* it installed. The skip test was `recorded dep == manifest dep`, with no check that the files on disk are actually that content — so once a record said "current" while the previous release''s files were still there, `--install` reported "already up to date" forever and the runtime was never replaced.

That is invisible at runtime: engines are keyed by the version the **loaded** `nvinfer` reports, so an install running 11.0 finds its cached `.trt-11.0.0` engines, matches, and upscales instantly — looking perfectly healthy while none of the 11.1 work is in play.

**Fix.** The builder records each pack''s extracted size as `installed_bytes` in `packs.json`; the updater re-installs whenever the pack''s files on disk do not sum to it. A different upstream build is a different size, and the check costs a directory stat. An index without the field (older release) keeps the previous behavior.

`--auto` had a second, independent gap: it selected packs missing **by name** (`!installed.ContainsKey`), so a pack whose governing dep had moved was never revisited — it reported "everything the detected hardware needs is already installed" after an upgrade. It now also re-installs when the recorded dep differs from the manifest, or when content does not match.

**Verified** by reproducing the exact broken state (record claims the current dep, file on disk is the previous build) with the real updater via `ANIMEJANAI_PACKS_DIR`:

| case | result |
| --- | --- |
| poisoned record + stale file, `--install` | detects mismatch → reinstalls → repaired |
| correct state, `--install` again | skips (no needless re-download) |
| stale dep record, `--auto` | reinstalls (previously a no-op) |
| builder-emitted index end-to-end, `--auto` | catches a 1-byte diff → repairs; second run is a clean no-op |

Emit side checked separately: `installed_bytes` equals the true on-disk total for all three pack shapes (multi-file `trt-runtime`, directory-expanded `rife`, single-file per-SM). Measured before `SlimInstallTree` removes the files.

Worth knowing (not a code issue): the updater resolves packs from `releases/latest`, which **excludes drafts**. While 3.6.0 sits unpublished, an install of it still resolves components against published 3.5.0 and refuses with *"Installed package is v3.6.0 but the published packs are for v3.5.0"* — so component upgrades can only be exercised after publishing (or via `ANIMEJANAI_PACKS_DIR`).